### PR TITLE
Disable import/no-anonymous-default-export in Rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-anonymous-default-export */
 import babel from 'rollup-plugin-babel';
 import commonjs from 'rollup-plugin-commonjs';
 import external from 'rollup-plugin-peer-deps-external';


### PR DESCRIPTION
Just turning off the eslint warnings in `rollup.config.js`