### PR TITLE
Theme now uses map keys instead of array indices for space

### DIFF
--- a/src/components/Badge/story.js
+++ b/src/components/Badge/story.js
@@ -15,7 +15,7 @@ const Flex = styled.div({ display: 'flex' }, flex, space);
 Flex.defaultProps = {
   justifyContent: 'flex-start',
   flex: '1 0 auto',
-  p: 3,
+  p: 'md',
   mb: 0,
 };
 
@@ -28,9 +28,9 @@ Box.displayName = 'Box';
 Box.defaultProps = {
   alignSelf: 'flex-start',
   justifyContent: 'center',
-  p: 3,
-  mb: 2,
-  mx: 2,
+  p: 'md',
+  mb: 'sm',
+  mx: 'sm',
 };
 
 storiesOf('Planets/Badge', module)
@@ -48,7 +48,7 @@ storiesOf('Planets/Badge', module)
       const variant = select('Variant', colorOptions, '');
 
       return (
-        <Box m={2} p={4}>
+        <Box m="sm" p="2xl">
           <Badge fontSize={fontSize} variant={variant}>
             {text('Children', 'My Badge')}
           </Badge>
@@ -65,7 +65,7 @@ storiesOf('Planets/Badge', module)
     <React.Fragment>
       <Box>
         <Badge>My Badge</Badge>
-        <Badge ml={2} bg="geyser" color="gray">
+        <Badge ml="sm" bg="geyser" color="gray">
           Other
         </Badge>
       </Box>
@@ -82,7 +82,7 @@ storiesOf('Planets/Badge', module)
         <Badge variant="info">Info Badge</Badge>
       </Box>
       <Box>
-        <Badge mr={2} variant="warning">
+        <Badge mr="sm" variant="warning">
           Warning Badge
         </Badge>
         <Badge bg="shuttle-gray" color="success">
@@ -94,13 +94,13 @@ storiesOf('Planets/Badge', module)
       </Box>
       <Box>
         <Flex m={0} p={0}>
-          <Badge mr={2} variant="info">
+          <Badge mr="sm" variant="info">
             Print
           </Badge>
-          <Badge mr={2} variant="info">
+          <Badge mr="sm" variant="info">
             Broadcast
           </Badge>
-          <Badge mr={2} variant="info">
+          <Badge mr="sm" variant="info">
             Radio
           </Badge>
           <Badge>Article</Badge>
@@ -109,13 +109,13 @@ storiesOf('Planets/Badge', module)
       <Box>
         <Flex m={0} p={0}>
           <Badge>Article</Badge>
-          <Badge ml={2} variant="info">
+          <Badge ml="sm" variant="info">
             Print
           </Badge>
-          <Badge ml={2} variant="info">
+          <Badge ml="sm" variant="info">
             Broadcast
           </Badge>
-          <Badge ml={2} variant="info">
+          <Badge ml="sm" variant="info">
             Radio
           </Badge>
         </Flex>

--- a/src/components/Badge/styled.js
+++ b/src/components/Badge/styled.js
@@ -24,7 +24,7 @@ const StyledBadge = styled.span`
 
 StyledBadge.defaultProps = {
   bg: null,
-  color: 'river-bed',
+  color: 'grayTints.4',
   fontFamily: 'body',
   fontSize: 0,
   ml: 0,

--- a/src/components/Bar/story.js
+++ b/src/components/Bar/story.js
@@ -18,11 +18,11 @@ Label.defaultProps = {
 };
 
 const Wrap = withDefaultTheme(styled.div(margin));
-Wrap.defaultProps = { m: 3 };
+Wrap.defaultProps = { m: 'md' };
 Wrap.displayName = 'Wrap';
 
 const Spacer = withDefaultTheme(styled.div(space));
-Spacer.defaultProps = { mb: 3 };
+Spacer.defaultProps = { mb: 'md' };
 Spacer.displayName = 'Spacer';
 
 const colorOptions = {
@@ -61,7 +61,7 @@ storiesOf('Star System/Bar', module)
     const fill = select('Fill', colorOptions, theme.colors.blue);
 
     return (
-      <Paper mx={3}>
+      <Paper mx="lg">
         <Bar bg={background}>
           <Fill bg={fill} width={`${value}%`} />
         </Bar>
@@ -71,21 +71,21 @@ storiesOf('Star System/Bar', module)
   })
   .add('Examples', () => (
     <Wrap>
-      <Paper mb={2}>
+      <Paper mb="sm">
         <h3>Default Bar</h3>
         <Bar>
           <Fill width="73%" />
         </Bar>
       </Paper>
 
-      <Paper mb={2}>
+      <Paper mb="sm">
         <h3>Custom Wrapper and Fill</h3>
         <Bar bg="loblolly">
           <Fill bg="salmon" width="50%" />
         </Bar>
       </Paper>
 
-      <Paper mb={2}>
+      <Paper mb="sm">
         <h3>Wrapper Width</h3>
         <Bar width="25%">
           <Fill bg="salmon" width="50%" />
@@ -104,7 +104,7 @@ storiesOf('Star System/Bar', module)
         </Bar>
       </Paper>
 
-      <Paper mb={2}>
+      <Paper mb="sm">
         <h3>Bars with multiple colors</h3>
         <Bar width="100%">
           <Fill bg="green" width="25%" />
@@ -113,7 +113,7 @@ storiesOf('Star System/Bar', module)
         </Bar>
       </Paper>
 
-      <Paper mb={2}>
+      <Paper mb="sm">
         <h3>At various fill widths...</h3>
         {[0, 10, 20, 50, 99, 100].map(percent => (
           <div key={`${percent}`.toString()}>

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { tagPropType } from '../../shared/propTypes';
+import { propTypes as tagPropTypes } from '../../shared/models/tag';
 
 import Addon from './Addon';
 
@@ -69,7 +69,7 @@ Button.propTypes = {
     'teal',
   ]),
   size: PropTypes.oneOf(['sm', 'md', 'lg']),
-  tag: tagPropType,
+  tag: tagPropTypes,
   type: PropTypes.string,
 };
 

--- a/src/components/Paper/README.md
+++ b/src/components/Paper/README.md
@@ -13,8 +13,8 @@ Paper provides a nice clean wrapper to separate pieces of content.
 The `<Paper>` wraper supports the `color`, `space`, `borderRadius` props from the `styled-system` utilities and supports theming using the default theme.
 
 ```js
-<Paper padding={3} bg="gray" color="white">
-  <Paper borderRadius={0} p={6}>
+<Paper p="lg" bg="gray" color="white">
+  <Paper borderRadius={0} p="4xl">
     {SampleText}
   </Paper>
   <Paper borderRadius={0} bg="green" color="white">

--- a/src/components/Paper/index.js
+++ b/src/components/Paper/index.js
@@ -9,7 +9,8 @@ Paper.defaultProps = {
   bg: 'white',
   borderRadius: '2px',
   color: 'gray',
-  p: 3,
+  p: 'lg',
+  m: 0,
 };
 
 Paper.propTypes = {

--- a/src/components/Paper/story.js
+++ b/src/components/Paper/story.js
@@ -8,7 +8,7 @@ import PaperReadme from './README.md';
 
 const Wrap = styled.div(margin);
 Wrap.defaultProps = {
-  m: 3,
+  m: 'md',
 };
 
 Wrap.displayName = 'Wrap';
@@ -33,29 +33,29 @@ storiesOf('Planets/Paper', module)
         <Wrap>
           <h2>Padding Examples</h2>
 
-          <Paper mb={3} p={0}>
+          <Paper mb="lg" p={0}>
             {SampleText}
           </Paper>
-          <Paper mb={3} p={1}>
+          <Paper mb="lg" p="xs">
             {SampleText}
           </Paper>
-          <Paper mb={3} p={2}>
+          <Paper mb="lg" p="sm">
             {SampleText}
           </Paper>
-          <Paper mb={3} p={3}>
+          <Paper mb="lg" p="lg">
             {SampleText}
           </Paper>
-          <Paper mb={3} p={4}>
+          <Paper mb="lg" p="2xl">
             {SampleText}
           </Paper>
-          <Paper mb={3} p={5}>
+          <Paper mb="lg" p="3xl">
             {SampleText}
           </Paper>
         </Wrap>
         <Wrap>
           <h3>Complex Nesting</h3>
-          <Paper padding={3} bg="gray" color="white">
-            <Paper borderRadius={0} p={6}>
+          <Paper p="lg" bg="gray" color="white">
+            <Paper borderRadius={0} p="4xl">
               {SampleText}
             </Paper>
             <Paper borderRadius={0} bg="green" color="white">

--- a/src/shared/colors.js
+++ b/src/shared/colors.js
@@ -1,0 +1,52 @@
+const colors = {
+  black: '#000',
+  blue: '#3398db',
+  blueTints: ['#50a7e0', '#e8f8fc'],
+  gray: '#414c52',
+  green: '#63bf52',
+  greenTints: ['#69cc58', '#e9fcf6'],
+  geyser: '#dee5e7',
+  hotPink: '#e62e5f',
+  hotPinkTints: ['#eb5c82', '#fce4ea'],
+  loblolly: '#c3cbcf',
+  porcelain: '#edf1f2',
+  'regent-gray': '#8a99a2',
+  'river-bed': '#4a5864',
+  salmon: '#f76764',
+  salmonTints: ['#f99794', '#feebea'],
+  'shuttle-gray': '#58666e',
+  teal: '#44c0c2',
+  tealTints: ['#47cacc', '#b7e7e8'],
+  white: '#fff',
+  whiteSmoke: '#f6f8f8',
+  yellow: '#f8ca00',
+  yellowTints: ['#ffd82c', '#fef8d3'],
+};
+
+colors.grayTints = [
+  colors['river-bed'],
+  colors['shuttle-gray'],
+  colors['regent-gray'],
+  colors.loblolly,
+  colors.geyser,
+  colors.porcelain,
+  colors.whiteSmoke,
+];
+
+colors.brandColor = colors.blue;
+colors.danger = colors.salmon;
+colors.notify = colors.hotPink;
+colors.info = colors.blue;
+colors.success = colors.green;
+colors.warning = colors.yellow;
+
+// aliases for backwards compatibility
+colors.blues = colors.blueTints;
+colors.greens = colors.greenTints;
+colors.hotPinks = colors.hotPinkTints;
+colors.salmons = colors.salmonTints;
+colors.teals = colors.tealTints;
+colors.yellows = colors.yellowTints;
+colors.grays = [colors.gray, ...colors.grayTints];
+
+export default colors;

--- a/src/shared/models/tag.js
+++ b/src/shared/models/tag.js
@@ -1,0 +1,23 @@
+import PropTypes from 'prop-types';
+
+export const propTypes = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.string,
+  PropTypes.shape({ $$typeof: PropTypes.symbol, render: PropTypes.func }),
+  PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.string,
+      PropTypes.shape({ $$typeof: PropTypes.symbol, render: PropTypes.func }),
+    ])
+  ),
+]);
+
+export const defaultProps = 'span';
+
+const tag = {
+  propTypes,
+  defaultProps,
+};
+
+export default tag;

--- a/src/shared/models/theme.js
+++ b/src/shared/models/theme.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+
+export const propTypes = {
+  breakpoints: PropTypes.arrayOf(PropTypes.string).isRequired,
+  colors: PropTypes.shape().isRequired,
+  fonts: PropTypes.shape({
+    heading: PropTypes.string.isRequired,
+    body: PropTypes.string.isRequired,
+    code: PropTypes.string.isRequired,
+  }).isRequired,
+  fontSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
+  radii: PropTypes.arrayOf(PropTypes.number).isRequired,
+  space: PropTypes.shape().isRequired,
+};
+
+const theme = {
+  propTypes,
+};
+
+export default theme;

--- a/src/shared/sizing.js
+++ b/src/shared/sizing.js
@@ -1,0 +1,41 @@
+export const borderWidthBase = 1;
+export const fontSizeBase = 14;
+export const sizeBase = 8;
+
+export const fontSizeMap = {
+  sm: fontSizeBase * (12 / 14), // 12px
+  md: fontSizeBase,
+  lg: fontSizeBase * (18 / 14), // 18px
+  xl: fontSizeBase * (25 / 14), // 25px
+  '2xl': fontSizeBase * (30 / 14), // 30px
+};
+
+export const lineHeightMap = {
+  sm: sizeBase * 2, // 16px
+  md: sizeBase * 2.5, // 20px
+};
+
+export const spaceMap = {
+  xs: sizeBase / 2, // 4px
+  sm: sizeBase, // 8px
+  md: sizeBase * 1.5, // 12px
+  lg: sizeBase * 2, // 16px
+  xl: sizeBase * 3, // 24px
+  '2xl': sizeBase * 4, // 32px
+  '3xl': sizeBase * 8, // 64px
+  '4xl': sizeBase * 16, // 128px
+};
+
+// For backwards compatibility
+export const fontSizes = Object.values(fontSizeMap);
+// End backwards compatibility
+
+export const sizing = {
+  fontSizeMap,
+  lineHeightMap,
+  spaceMap,
+};
+
+export const subtractBorder = size => size - borderWidthBase;
+
+export default sizing;

--- a/src/shared/theme.js
+++ b/src/shared/theme.js
@@ -1,44 +1,5 @@
-const colors = {
-  black: '#000',
-  blue: '#3398db',
-  blues: ['#50a7e0', '#e8f8fc'],
-  gray: '#414c52',
-  green: '#63bf52',
-  greens: ['#69cc58', '#e9fcf6'],
-  geyser: '#dee5e7',
-  hotPink: '#e62e5f',
-  hotPinks: ['tint($notifycolorbase, 10%)', 'tint($notifycolorbase, 50%)'],
-  loblolly: '#c3cbcf',
-  porcelain: '#edf1f2',
-  'regent-gray': '#8a99a2',
-  'river-bed': '#4a5864',
-  salmon: '#f76764',
-  salmons: ['#feebea'],
-  'shuttle-gray': '#58666e',
-  teal: '#44c0c2',
-  teals: ['#47cacc'],
-  white: '#fff',
-  yellow: '#f8ca00',
-  yellows: ['#fef8d3'],
-};
-
-colors.grays = [
-  colors.gray,
-  colors['river-bed'],
-  colors['shuttle-gray'],
-  colors['regent-gray'],
-  colors.loblolly,
-  colors.geyser,
-  colors.porcelain,
-  '#f6f8f8',
-];
-
-colors.brandColor = colors.blue;
-colors.danger = colors.salmon;
-colors.notify = colors.hotPink;
-colors.info = colors.blue;
-colors.success = colors.green;
-colors.warning = colors.yellow;
+import colors from './colors';
+import { fontSizes, spaceMap } from './sizing';
 
 const fontFamilies = {
   heading: "'Source Sans Pro', sans-serif",
@@ -46,15 +7,13 @@ const fontFamilies = {
   code: 'Roboto Mono, monospace',
 };
 
-const fontSizes = [12, 14, 18, 25, 30];
-
 const defaultTheme = {
   breakpoints: ['450px', '599px'],
-  space: [0, 4, 8, 16, 32, 64, 128],
-  radii: [0, 2, 9999],
   colors,
-  fontSizes,
   fonts: fontFamilies,
+  fontSizes,
+  radii: [0, 2, 9999],
+  space: spaceMap,
 };
 
 export default defaultTheme;

--- a/src/stories.js
+++ b/src/stories.js
@@ -10,10 +10,8 @@ import './shared/reset.css';
  */
 
 import './components/Badge/story';
-import './components/Bar/story';
 import './components/Button/story';
 import './components/Paper/story';
-import './components/Responsive/story';
 
 /*
  * STAR SYSTEMS
@@ -21,6 +19,8 @@ import './components/Responsive/story';
  * but should be minimal.
  * eg: Button group, dropdown toggle, checkbox group
  */
+
+import './components/Bar/story';
 
 /*
  * GALAXIES
@@ -34,3 +34,5 @@ import './components/Responsive/story';
  * just the layout.
  * eg: Responsive layout
  */
+
+import './components/Responsive/story';


### PR DESCRIPTION
* Added maps with human-readable keys for accessing theme "space" props
* Added color `*Tints` arrays to make it clearer that `grayTints.4` is lighter than `grayTints.0`, which is lighter than `gray`
* Updated existing stories, tests, readmes to use new key names for space and color.
* Moved font sizes, colors, and spacing to their own js files, imported by theme.js
* Organized stories.js imports by planet / star system, etc.