### PR TITLE
Move css imports to js instead of @imports as temp fix for bundling

### DIFF
--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -6,6 +6,7 @@ import { propTypes as tagPropTypes } from '../../shared/models/tag';
 
 import Addon from './Addon';
 
+import './colors.css';
 import style from './style.css';
 
 const Button = props => {

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -1,5 +1,3 @@
-@import './colors.css';
-
 .Button {
   -webkit-appearance: none;
   background: transparent none;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
 // Global CSS variables
+import './shared/colors.css';
+import './shared/sizing.css';
 import './shared/variables.css';
 import './shared/reset.css';
 

--- a/src/shared/variables.css
+++ b/src/shared/variables.css
@@ -1,6 +1,3 @@
-@import "./colors.css";
-@import "./sizing.css";
-
 :root {
   /* Colors */
   --box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
@imports in css weren't working with our rollup config for some reason. That caused our css variables to fail to import, and a bunch of styles to disappear.

The imports worked in javascript, though. I tested this with `yarn link` locally, seems good.