### PR TITLE
Remove overflow-hidden rule for tooltips and box-shadows in grid entries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.3",
+  "version": "0.1.0-alpha.4",
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",
   "contributors": [

--- a/src/components/Grid/style.css
+++ b/src/components/Grid/style.css
@@ -1,7 +1,3 @@
-.Grid {
-  overflow: hidden;
-}
-
 .Columns {
   display: flex;
   flex-flow: row wrap;


### PR DESCRIPTION
Thought this would be a good idea, but it truncates box shadows on grid entries.
It would also be problematic for tooltips.