### PR TITLE
Use flexbox correctly and just use divs for Media

### DIFF
--- a/src/components/Media/styled.js
+++ b/src/components/Media/styled.js
@@ -1,28 +1,20 @@
-import React from 'react';
 import styled from 'styled-components';
-import { space, flex } from 'styled-system';
-import { propTypes as TagType } from '../../shared/models/tag';
+import { space, flexbox } from 'styled-system';
 import withDefaultTheme from '../withDefaultTheme';
 
-const BaseMediaObj = ({ tag: Tag, ...props }) => <Tag {...props} />;
-BaseMediaObj.propTypes = {
-  tag: TagType,
-};
-
-BaseMediaObj.defaultProps = {
-  tag: 'div',
-};
-
-export const StyledMedia = withDefaultTheme(styled(BaseMediaObj)`
+export const StyledMedia = withDefaultTheme(styled.div`
   display: flex;
   flex-flow: row nowrap;
-  align-items: stretch;
   width: 100%;
-  ${flex}
+  ${flexbox}
   ${space}
 `);
 
-export const StyledBody = withDefaultTheme(styled(BaseMediaObj)`
+StyledMedia.defaultProps = {
+  alignItems: 'stretch',
+};
+
+export const StyledBody = withDefaultTheme(styled.div`
   flex: 1 1 auto;
   min-width: 0;
   display: grid;
@@ -30,7 +22,7 @@ export const StyledBody = withDefaultTheme(styled(BaseMediaObj)`
   ${space}
 `);
 
-export const StyledItem = withDefaultTheme(styled(BaseMediaObj)`
+export const StyledItem = withDefaultTheme(styled.div`
   flex: 0 0 auto;
   display: grid;
   grid-template-columns: 100%;

--- a/src/components/Media/test.js
+++ b/src/components/Media/test.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 
 import Media from './';
 
 describe('Media', () => {
   describe('Media.Item', () => {
-    it('supports custom tags', () => {
+    xit('supports custom tags', () => {
       const wrapper = mount(
         <Media tag="main">
           <Media.Item tag="aside">Hello</Media.Item>
@@ -29,7 +29,7 @@ describe('Media', () => {
   });
 
   describe('Media.Body', () => {
-    it('supports custom tags', () => {
+    xit('supports custom tags', () => {
       const wrapper = mount(
         <Media tag="main">
           <Media.Body tag="content">Hello</Media.Body>


### PR DESCRIPTION
> Duplicate of #62 after master branch cleanup

To make sure we can configure flexbox properties correctly, we are dropping the custom tag support for Media components (for now).

Also, include the `flexbox` utility correctly.