### PR TITLE
flexbox is for styled-system 5

### DIFF
--- a/src/components/Media/styled.js
+++ b/src/components/Media/styled.js
@@ -1,12 +1,12 @@
 import styled from 'styled-components';
-import { space, flexbox } from 'styled-system';
+import { space, flex } from 'styled-system';
 import withDefaultTheme from '../withDefaultTheme';
 
 export const StyledMedia = withDefaultTheme(styled.div`
   display: flex;
   flex-flow: row nowrap;
   width: 100%;
-  ${flexbox}
+  ${flex}
   ${space}
 `);
 


### PR DESCRIPTION
`flexbox` was referenced in the website's documentation. However, unbeknownst to me, there was a major version bump and this changed the name of the utility from `flex` to `flexbox`. This reverts back to `flex` for the version fo styled-system we are currently using.