### PR TITLE
Add TabMenu component, including Item and SimpleTabMenu

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.8",
+  "version": "0.1.0-alpha.9",
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",
   "contributors": [

--- a/src/components/TabMenu/Item/index.js
+++ b/src/components/TabMenu/Item/index.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import style from './style.css';
+
+const Item = ({
+  size,
+  className: customClassName,
+  active,
+  onClick,
+  children,
+  ...props
+}) => {
+  const isChildActive = child => {
+    if (typeof child !== 'object') return false;
+    if ((child.props || {}).className) {
+      return child.props.className.indexOf('active') >= 0;
+    }
+    return false;
+  };
+
+  const className = classNames(style.TabItem, customClassName, {
+    [style.active]: active || isChildActive(children),
+  });
+  return (
+    <li className={className} {...props}>
+      {children}
+    </li>
+  );
+};
+
+Item.propTypes = {
+  size: PropTypes.number,
+  className: PropTypes.string,
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
+  children: PropTypes.node.isRequired,
+};
+
+Item.defaultProps = {
+  size: 16,
+  className: '',
+  active: false,
+  onClick: () => {},
+};
+
+export default Item;

--- a/src/components/TabMenu/Item/index.js
+++ b/src/components/TabMenu/Item/index.js
@@ -4,23 +4,15 @@ import PropTypes from 'prop-types';
 
 import style from './style.css';
 
-const Item = ({
-  size,
-  className: customClassName,
-  active,
-  onClick,
-  children,
-  ...props
-}) => {
+const Item = ({ className: customClassName, active, children, ...props }) => {
   const isChildActive = child => {
-    if (typeof child !== 'object') return false;
-    if ((child.props || {}).className) {
+    if (React.isValidElement(child)) {
       return child.props.className.indexOf('active') >= 0;
     }
     return false;
   };
 
-  const className = classNames(style.TabItem, customClassName, {
+  const className = classNames(style.Item, customClassName, {
     [style.active]: active || isChildActive(children),
   });
   return (
@@ -31,15 +23,12 @@ const Item = ({
 };
 
 Item.propTypes = {
-  size: PropTypes.number,
   className: PropTypes.string,
   active: PropTypes.bool,
-  onClick: PropTypes.func,
   children: PropTypes.node.isRequired,
 };
 
 Item.defaultProps = {
-  size: 16,
   className: '',
   active: false,
   onClick: () => {},

--- a/src/components/TabMenu/Item/style.css
+++ b/src/components/TabMenu/Item/style.css
@@ -1,4 +1,4 @@
-.TabItem {
+.Item {
   color: var(--rvr-gray-lite-1);
   font-weight: normal;
   padding: 0;
@@ -8,7 +8,7 @@
   box-sizing: content-box;
 }
 
-.TabItem:hover {
+.Item:hover {
   color: var(--rvr-gray);
   cursor: pointer;
 }

--- a/src/components/TabMenu/Item/style.css
+++ b/src/components/TabMenu/Item/style.css
@@ -1,0 +1,20 @@
+.TabItem {
+  color: var(--rvr-gray-lite-1);
+  font-weight: normal;
+  padding: 0;
+  margin: 0 12px;
+  display: block;
+  border-bottom: 2px solid transparent;
+  box-sizing: content-box;
+}
+
+.TabItem:hover {
+  color: var(--rvr-gray);
+  cursor: pointer;
+}
+
+.active {
+  color: var(--rvr-gray);
+  font-weight: 700;
+  border-bottom-color: var(--rvr-blue);
+}

--- a/src/components/TabMenu/README.md
+++ b/src/components/TabMenu/README.md
@@ -1,0 +1,11 @@
+# TabMenu
+
+1. `<TabMenu>` Controls the flex children and alignment of the tab menu. Any styles/classNames and extra props passed will be passed down
+2. `<TabMenu.Item>` Lightly styled inner tab item. `Active` prop automatically adds blue underline, but you will need to add your own padding to the clickable child element (import `itemPadding` for standard padding);
+3. `<SimpleTabMenu>` utilizes both of the above, for an out-of-the-box tab menu
+
+## When to use SimpleTabMenu vs customized TabMenu
+
+With `SimpleTabMenu`, you pass an array of objects including a key, label, and onClick event, as well as `activeTab` (which corresponds to one of the array item's keys). If you need the tab item to do anything other than a function (eg. be a NavLink) then you can utilize `TabMenu` with `TabMenu.Item` children.
+
+**BONUS** If a child of TabMenu.Item has a className including "active", it will automatically apply the active styling. So, if you do need a list of NavLinks inside the Tab Menus, you shouldn't have to control which one is active!

--- a/src/components/TabMenu/index.js
+++ b/src/components/TabMenu/index.js
@@ -55,7 +55,7 @@ SimpleTabMenu.propTypes = {
 SimpleTabMenu.defaultProps = {
   tabs: [],
   activeTab: '',
-  size: 'sm',
+  size: 'md',
 };
 
 export default TabMenu;

--- a/src/components/TabMenu/index.js
+++ b/src/components/TabMenu/index.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import Item from './Item';
+import style from './style.css';
+
+const TabMenu = ({ align, className, ...props }) => {
+  const tabMenuClass = classNames(
+    style.TabMenu,
+    className,
+    style[`${align}Align`]
+  );
+  return <ul className={tabMenuClass} {...props} />;
+};
+
+TabMenu.Item = Item;
+export const itemPadding = style.itemPadding;
+
+TabMenu.propTypes = {
+  align: PropTypes.oneOf(['left', 'center', 'right']),
+  className: PropTypes.string,
+};
+TabMenu.defaultProps = {
+  align: 'left',
+  className: '',
+};
+
+export const SimpleTabMenu = ({ tabs, activeTab, size = 'sm', ...props }) => {
+  const inner = classNames(style.itemPadding, style[`${size}TextSize`]);
+  return (
+    <TabMenu {...props}>
+      {tabs.map(tab => (
+        <Item key={tab.key} active={tab.key === activeTab}>
+          <button className={inner} onClick={tab.onClick}>
+            {tab.label}
+          </button>
+        </Item>
+      ))}
+    </TabMenu>
+  );
+};
+
+SimpleTabMenu.propTypes = {
+  tabs: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      onClick: PropTypes.func,
+    }).isRequired
+  ),
+  activeTab: PropTypes.string,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+};
+SimpleTabMenu.defaultProps = {
+  tabs: [],
+  activeTab: '',
+  size: 'sm',
+};
+
+export default TabMenu;

--- a/src/components/TabMenu/story.js
+++ b/src/components/TabMenu/story.js
@@ -1,0 +1,135 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { text, select, boolean } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+import TabMenu, { SimpleTabMenu, itemPadding } from './';
+import Readme from './README.md';
+
+storiesOf('Star Systems/TabMenu', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => {
+      const alignment = select('align', ['left', 'center', 'right'], 'left');
+      return (
+        <TabMenu align={alignment}>
+          <TabMenu.Item>
+            <a
+              className={itemPadding}
+              onClick={action()}
+              role="button"
+              tabIndex={0}
+            >
+              Anything
+            </a>
+          </TabMenu.Item>
+          <TabMenu.Item>
+            <a
+              className={`${itemPadding} active`}
+              onClick={action()}
+              role="button"
+              tabIndex={0}
+            >
+              Goes
+            </a>
+          </TabMenu.Item>
+          <TabMenu.Item>
+            <a
+              className={itemPadding}
+              onClick={action()}
+              role="button"
+              tabIndex={0}
+            >
+              Here
+            </a>
+          </TabMenu.Item>
+        </TabMenu>
+      );
+    },
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  );
+
+storiesOf('Star Systems/TabMenu/Item', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => {
+      return (
+        <div style={{ display: 'flex' }}>
+          <TabMenu.Item active={boolean('active', true)}>
+            <span className={itemPadding}>{text('children', 'Text Here')}</span>
+          </TabMenu.Item>
+        </div>
+      );
+    },
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  );
+
+storiesOf('Star Systems/TabMenu/SimpleTabMenu', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add('Overview', () => {
+    const withContainer = boolean('With Container', false);
+    const sizeOptions = select('size', ['xs', 'sm', 'md', 'lg'], 'sm');
+    const activeTab = select('activeTab', ['ONE', 'TWO', 'THREE'], 'ONE');
+    const alignment = select('align', ['left', 'center', 'right'], 'left');
+    if (!withContainer) {
+      return (
+        <SimpleTabMenu
+          align={alignment}
+          size={sizeOptions}
+          tabs={[
+            { key: 'ONE', label: 'One', onClick: action() },
+            { key: 'TWO', label: 'Two', onClick: action() },
+            {
+              key: 'THREE',
+              label: 'Three',
+              onClick: action(),
+            },
+          ]}
+          activeTab={activeTab}
+        />
+      );
+    }
+    return (
+      <div style={{ background: '#ffffff', padding: '0px 20px' }}>
+        <SimpleTabMenu
+          style={{ borderBottom: '1px solid #ccc' }}
+          align={alignment}
+          size={sizeOptions}
+          tabs={[
+            { key: 'ONE', label: 'One', onClick: action() },
+            { key: 'TWO', label: 'Two', onClick: action() },
+            {
+              key: 'THREE',
+              label: 'Three',
+              onClick: action(),
+            },
+          ]}
+          activeTab={activeTab}
+        />
+      </div>
+    );
+  });

--- a/src/components/TabMenu/style.css
+++ b/src/components/TabMenu/style.css
@@ -1,0 +1,37 @@
+.TabMenu {
+  display: flex;
+  align-items: flex-end;
+  padding: 0;
+  margin: 0;
+  list-style-type: none;
+}
+
+.leftAlign {
+  justify-content: flex-start;
+}
+
+.centerAlign {
+  justify-content: center;
+}
+
+.rightAlign {
+  justify-content: flex-end;
+}
+
+/* SimpleTabMenu uses these */
+.itemPadding {
+  padding: 16px 0;
+
+  /* reset default button styles */
+  background-color: transparent;
+  border: none;
+  color: inherit;
+  text-decoration: none;
+  display: block;
+  border-radius: 0;
+}
+
+.xsTextSize { font-size: 14px; }
+.smTextSize { font-size: 16px; }
+.mdTextSize { font-size: 18px; }
+.lgTextSize { font-size: 20px; }

--- a/src/components/TabMenu/style.css
+++ b/src/components/TabMenu/style.css
@@ -31,7 +31,7 @@
   border-radius: 0;
 }
 
-.xsTextSize { font-size: 14px; }
-.smTextSize { font-size: 16px; }
-.mdTextSize { font-size: 18px; }
-.lgTextSize { font-size: 20px; }
+.xsTextSize { font-size: var(--rvr-font-size-sm); }
+.smTextSize { font-size: var(--rvr-font-size-md); }
+.mdTextSize { font-size: var(--rvr-font-size-h4); }
+.lgTextSize { font-size: var(--rvr-font-size-h3); }

--- a/src/components/TabMenu/test.js
+++ b/src/components/TabMenu/test.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import TabMenu, { SimpleTabMenu } from './';
+
+describe('TabMenu', () => {
+  it('renders', () => {
+    shallow(<TabMenu>Boom</TabMenu>);
+  });
+
+  it('Renders correctly', () => {
+    const wrapper = shallow(
+      <TabMenu className="customClass">
+        <div>item</div>
+        <div>item</div>
+      </TabMenu>
+    );
+
+    expect(wrapper.find('ul').children()).toHaveLength(2);
+    expect(wrapper.hasClass('customClass')).toEqual(true);
+  });
+});
+
+describe('TabMenu.Item', () => {
+  it('is not active by default', () => {
+    const inactive = mount(<TabMenu.Item>I am inactive :(</TabMenu.Item>);
+
+    expect(inactive.prop('active')).not.toBe(true);
+  });
+});
+
+describe('SimpleTabMenu', () => {
+  it('has the same number of children as array items', () => {
+    const wrapper = shallow(
+      <SimpleTabMenu
+        tabs={[
+          { key: 'one', label: 'first', onClick: () => {} },
+          { key: 'two', label: 'second', onClick: () => {} },
+        ]}
+      />
+    );
+    expect(wrapper.children()).toHaveLength(2);
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -12,3 +12,4 @@ export { default as Paper } from './components/Paper';
 export { default as Grid } from './components/Grid';
 export { default as Responsive } from './components/Responsive';
 export { default as SideTray } from './components/SideTray';
+export { default as TabMenu } from './components/TabMenu';

--- a/src/shared/sizing.css
+++ b/src/shared/sizing.css
@@ -23,7 +23,12 @@
 
   /* font-size */
   --rvr-font-size-base: 14px;
+  --rvr-font-size-h1: 42px;
+  --rvr-font-size-h2: 30px;
+  --rvr-font-size-h3: 25px;
+  --rvr-font-size-h4: 16px;
   --rvr-font-size-md: 14px;
+  --rvr-font-size-sm: 12px;
 
   /* line-height */
   --rvr-line-height-sm: calc(var(--rvr-baseSize) * 2);    /* 16px */

--- a/src/shared/sizing.js
+++ b/src/shared/sizing.js
@@ -4,10 +4,11 @@ export const sizeBase = 8;
 
 export const fontSizeMap = {
   sm: fontSizeBase * (12 / 14), // 12px
-  md: fontSizeBase,
-  lg: fontSizeBase * (18 / 14), // 18px
-  xl: fontSizeBase * (25 / 14), // 25px
-  '2xl': fontSizeBase * (30 / 14), // 30px
+  md: fontSizeBase, // 14px
+  h4: fontSizeBase * (16 / 14), // 16px
+  h3: fontSizeBase * (24 / 14), // 24px
+  h2: fontSizeBase * (32 / 14), // 32px
+  h1: fontSizeBase * (40 / 14), // 40px
 };
 
 export const lineHeightMap = {

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -27,6 +27,7 @@ import '../components/Paper/story';
 
 import '../components/Bar/story';
 import '../components/SideTray/story';
+import './components/TabMenu/story';
 
 /*
  * GALAXIES


### PR DESCRIPTION
**SUMMARY**
Add tabMenu (which exists in TK-UI and APP buuuuuut I wanted it to be more usable out of the box. 

sooooo as part of this, we have a SimpleTabMenu (which just takes an array and a couple other props) and a rather simple TabMenu + Item set of components which can be customized for behavior but manage to keep the same look as all the other tab menus.

This will be used extensively in iHub
<img width="808" alt="Screen Shot 2019-07-25 at 10 08 54 PM" src="https://user-images.githubusercontent.com/16182107/61923234-d7778e00-af28-11e9-9f87-8297d5d3074f.png">
