### PR TITLE
Fix export SimpleTabMenu

### DIFF
--- a/_templates/component/new/storyimport.t
+++ b/_templates/component/new/storyimport.t
@@ -2,6 +2,6 @@
 inject: true
 to: src/stories/index.js
 after: INJECTOR
-skip_if: ./components/<%= h.changeCase.pascal(name) %>/story
+skip_if: ../components/<%= h.changeCase.pascal(name) %>/story
 ---
-import './components/<%= h.changeCase.pascal(name) %>/story';
+import '../components/<%= h.changeCase.pascal(name) %>/story';

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -9,10 +9,12 @@ import {
   Grid,
   Responsive,
   SideTray,
+  SimpleTabMenu,
 } from '@cision/rover-ui';
 
 const App = () => {
   const [isSideTrayOpen, setIsSideTrayOpen] = useState(false);
+  const [activeTab, setActiveTab] = useState('ONE');
 
   return (
     <div>
@@ -108,6 +110,31 @@ const App = () => {
               </p>
             </div>
           </SideTray>
+        </div>
+      </section>
+      <section>
+        <h1>SimpleTabMenu</h1>
+        <div style={{ background: 'white', padding: '0 20px' }}>
+          <SimpleTabMenu
+            tabs={[
+              {
+                key: 'ONE',
+                label: 'First',
+                onClick: () => setActiveTab('ONE'),
+              },
+              {
+                key: 'TWO',
+                label: 'Second',
+                onClick: () => setActiveTab('TWO'),
+              },
+              {
+                key: 'THREE',
+                label: 'Three',
+                onClick: () => setActiveTab('THREE'),
+              },
+            ]}
+            activeTab={activeTab}
+          />
         </div>
       </section>
     </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.9",
+  "version": "0.1.0-alpha.10",
+  "publishConfig": {
+    "tag": "v0.1.0-alpha.10"
+  },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",
   "contributors": [
@@ -52,7 +55,8 @@
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "storybook": "start-storybook -p 9009",
-    "build-storybook": "build-storybook"
+    "build-storybook": "build-storybook",
+    "prepublish": "yarn build"
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",

--- a/src/index.js
+++ b/src/index.js
@@ -12,4 +12,4 @@ export { default as Paper } from './components/Paper';
 export { default as Grid } from './components/Grid';
 export { default as Responsive } from './components/Responsive';
 export { default as SideTray } from './components/SideTray';
-export { default as TabMenu } from './components/TabMenu';
+export { default as TabMenu, SimpleTabMenu } from './components/TabMenu';

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -27,7 +27,7 @@ import '../components/Paper/story';
 
 import '../components/Bar/story';
 import '../components/SideTray/story';
-import './components/TabMenu/story';
+import '../components/TabMenu/story';
 
 /*
  * GALAXIES


### PR DESCRIPTION
Last deploy didn't export SimpleTabMenu with TabMenu. 

Also, added to example. Does this need a version bump?