### PR TITLE
0.1.0-alpha.11 // Update tab menu

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -9,7 +9,7 @@ import {
   Grid,
   Responsive,
   SideTray,
-  SimpleTabMenu,
+  EasyTabMenu,
 } from '@cision/rover-ui';
 
 const App = () => {
@@ -113,9 +113,9 @@ const App = () => {
         </div>
       </section>
       <section>
-        <h1>SimpleTabMenu</h1>
+        <h1>EasyTabMenu</h1>
         <div style={{ background: 'white', padding: '0 20px' }}>
-          <SimpleTabMenu
+          <EasyTabMenu
             tabs={[
               {
                 key: 'ONE',

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -6658,15 +6658,9 @@ react-scripts@^1.1.4:
   optionalDependencies:
     fsevents "^1.1.3"
 
-react@^16.8.0:
-  version "16.8.6"
-  resolved "https://trendkite.jfrog.io/trendkite/api/npm/libs-frontend/react/-/react-16.8.6.tgz#ad6c3a9614fd3a4e9ef51117f54d888da01f2bbe"
-  integrity sha1-rWw6lhT9Ok6e9REX9U2IjaAfK74=
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.2"
-    scheduler "^0.13.6"
+"react@link:../node_modules/react":
+  version "0.0.0"
+  uid ""
 
 read-pkg-up@^1.0.1:
   version "1.0.1"

--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "storybook": "start-storybook -p 9009",
-    "build-storybook": "build-storybook",
-    "prepublish": "yarn build"
+    "build-storybook": "build-storybook"
   },
   "peerDependencies": {
     "prop-types": "^15.5.4",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.10",
+  "version": "0.1.0-alpha.11",
   "publishConfig": {
-    "tag": "v0.1.0-alpha.10"
+    "tag": "v0.1.0-alpha.11"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",

--- a/src/components/TabMenu/Item/style.css
+++ b/src/components/TabMenu/Item/style.css
@@ -8,6 +8,14 @@
   box-sizing: content-box;
 }
 
+.Item:first-of-type {
+  margin-left: 0;
+}
+
+.Item:last-of-type {
+  margin-right: 0;
+}
+
 .Item:hover {
   color: var(--rvr-gray);
   cursor: pointer;

--- a/src/components/TabMenu/index.js
+++ b/src/components/TabMenu/index.js
@@ -26,6 +26,10 @@ TabMenu.defaultProps = {
   className: '',
 };
 
+/*
+ * SimpleComponent naming convention is deprecated due to confusion.
+ * Use EasyComponent moving forward.
+ */
 export const SimpleTabMenu = ({ tabs, activeTab, size = 'sm', ...props }) => {
   const inner = classNames(style.itemPadding, style[`${size}TextSize`]);
   return (
@@ -40,6 +44,8 @@ export const SimpleTabMenu = ({ tabs, activeTab, size = 'sm', ...props }) => {
     </TabMenu>
   );
 };
+
+export const EasyTabMenu = SimpleTabMenu;
 
 SimpleTabMenu.propTypes = {
   tabs: PropTypes.arrayOf(

--- a/src/index.js
+++ b/src/index.js
@@ -12,4 +12,8 @@ export { default as Paper } from './components/Paper';
 export { default as Grid } from './components/Grid';
 export { default as Responsive } from './components/Responsive';
 export { default as SideTray } from './components/SideTray';
-export { default as TabMenu, SimpleTabMenu } from './components/TabMenu';
+export {
+  default as TabMenu,
+  SimpleTabMenu,
+  EasyTabMenu,
+} from './components/TabMenu';


### PR DESCRIPTION
light style updates to TabMenu.Item, and export `EasyTabMenu` so we can switch over to that in the app and remove `SimpleTabMenu`