### PR TITLE
Add Pill, DeletablePill, EasyPill

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -11,6 +11,10 @@ import {
   Responsive,
   SideTray,
   EasyTabMenu,
+  Pill,
+  DeletablePill,
+  EasyPill,
+  // IMPORT_INJECTOR
 } from '@cision/rover-ui';
 
 const App = () => {
@@ -141,6 +145,51 @@ const App = () => {
       <section>
         <h1>Icon</h1>
         <Icon name="clear" />
+      </section>
+      <section>
+        <h1>Pill</h1>
+        <Pill onClick={() => {}} checked>
+          Pill with addon
+          <Pill.Addon onClick={() => {}}>✓</Pill.Addon>
+        </Pill>
+      </section>
+      <section>
+        <h1>DeletablePill</h1>
+        <DeletablePill onDelete={() => {}} checked>
+          DeletablePill
+        </DeletablePill>
+      </section>
+      <section>
+        <h1>EasyPill</h1>
+        <EasyPill
+          actions={[
+            {
+              label: '✓',
+              onClick: () => {},
+            },
+            {
+              label: '✰',
+              onClick: () => {},
+            },
+          ]}
+        >
+          EasyPill
+        </EasyPill>{' '}
+        <EasyPill
+          actions={[
+            {
+              label: '✓',
+              onClick: () => {},
+            },
+            {
+              label: '✰',
+              onClick: () => {},
+            },
+          ]}
+          checked
+        >
+          EasyPill checked
+        </EasyPill>
       </section>
       {/** USAGE_INJECTOR */}
     </div>

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -144,7 +144,7 @@ const App = () => {
       </section>
       <section>
         <h1>Icon</h1>
-        <Icon name="clear" />
+        <Icon name="times-circle" />
       </section>
       <section>
         <h1>Pill</h1>

--- a/src/components/DeletablePill/README.md
+++ b/src/components/DeletablePill/README.md
@@ -1,6 +1,5 @@
 # DeletablePill
 
-When checked, clicking anywhere on a deletable pill fires an `onDelete` function.
-When checked, the pill also has a small "clear" icon.
+When checked, the pill has a small delete icon (⊗). Clicking it fires an `onDelete` function.
 
 When unchecked, it behaves just like a regular pill.

--- a/src/components/DeletablePill/README.md
+++ b/src/components/DeletablePill/README.md
@@ -1,0 +1,6 @@
+# DeletablePill
+
+When checked, clicking anywhere on a deletable pill fires an `onDelete` function.
+When checked, the pill also has a small "clear" icon.
+
+When unchecked, it behaves just like a regular pill.

--- a/src/components/DeletablePill/index.js
+++ b/src/components/DeletablePill/index.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from '../Icon';
+import Pill from '../Pill';
+
+export const DeletablePill = ({ children, onDelete, ...passedProps }) => {
+  return (
+    <Pill {...passedProps} onClick={passedProps.checked ? onDelete : undefined}>
+      {children}
+      {passedProps.checked && (
+        <Pill.Addon>
+          <Icon name="clear" style={{ display: 'block' }} />
+        </Pill.Addon>
+      )}
+    </Pill>
+  );
+};
+
+DeletablePill.propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  onDelete: PropTypes.func.isRequired,
+};
+
+DeletablePill.defaultProps = {
+  checked: false,
+};
+
+export default DeletablePill;

--- a/src/components/DeletablePill/index.js
+++ b/src/components/DeletablePill/index.js
@@ -6,11 +6,18 @@ import Pill from '../Pill';
 
 export const DeletablePill = ({ children, onDelete, ...passedProps }) => {
   return (
-    <Pill {...passedProps} onClick={passedProps.checked ? onDelete : undefined}>
+    <Pill {...passedProps}>
       {children}
       {passedProps.checked && (
-        <Pill.Addon>
-          <Icon name="clear" style={{ display: 'block' }} />
+        <Pill.Addon
+          onClick={e => {
+            e.stopPropagation();
+            onDelete(e);
+          }}
+          role="button"
+          tabIndex={0}
+        >
+          <Icon name="times-circle" style={{ display: 'block' }} />
         </Pill.Addon>
       )}
     </Pill>

--- a/src/components/DeletablePill/story.js
+++ b/src/components/DeletablePill/story.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+
+import DeletablePill from './';
+import Readme from './README.md';
+
+storiesOf('Star Systems/DeletablePill', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => (
+      <DeletablePill
+        checked={boolean('checked', false)}
+        onClick={action('onClick')}
+        onDelete={action('onDelete')}
+      >
+        DeletablePill 1
+      </DeletablePill>
+    ),
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  );

--- a/src/components/DeletablePill/test.js
+++ b/src/components/DeletablePill/test.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import Icon from '../Icon';
+import DeletablePill from './';
+
+describe('DeletablePill', () => {
+  it('renders', () => {
+    shallow(<DeletablePill onDelete={() => {}}>DeletablePill</DeletablePill>);
+  });
+
+  describe('with children', () => {
+    it('renders its children', () => {
+      const wrapper = mount(
+        <DeletablePill onDelete={() => {}}>DeletablePill 1</DeletablePill>
+      );
+
+      expect(wrapper.children()).toHaveLength(1);
+      expect(wrapper.text()).toEqual('DeletablePill 1');
+    });
+  });
+
+  describe('when unchecked', () => {
+    it("doesn't show clear action", () => {
+      const wrapper = mount(
+        <DeletablePill onDelete={() => {}}>DeletablePill 1</DeletablePill>
+      );
+
+      const clear = wrapper.find(Icon);
+
+      expect(clear).toHaveLength(0);
+    });
+  });
+
+  describe('when checked', () => {
+    it('shows clear action', () => {
+      const wrapper = mount(
+        <DeletablePill checked onDelete={() => {}}>
+          DeletablePill 1
+        </DeletablePill>
+      );
+
+      const clear = wrapper.find(Icon);
+
+      expect(clear).toHaveLength(1);
+    });
+  });
+});

--- a/src/components/EasyPill/README.md
+++ b/src/components/EasyPill/README.md
@@ -1,0 +1,12 @@
+# EasyPill
+
+Easy pills are more opinionated than basic pills, to make it easy to get started on the most common use cases.
+They take an `actions` prop that's an array of objects.
+Each object has, at least, a callback function (`onClick`) and a text label (`label`).
+
+Easy pills show those action labels in a list. Each one fires its callback function when clicked.
+Easy pill actions may also have `children` props, in which case they'll render the `children` as a React node instead of the label. You still need to provide a unique text label, though, for use as an identifying key.
+
+Easy pills come with a delete action by default. If you provide an `onDelete` function as a prop, it will show up automatically.
+
+**TODO**: The easy pill's actions should be in a small dropdown with an ellipsis icon that triggers it.

--- a/src/components/EasyPill/index.js
+++ b/src/components/EasyPill/index.js
@@ -28,7 +28,7 @@ export const EasyPill = ({ actions, children, onDelete, ...passedProps }) => {
             onDelete(e);
           }}
         >
-          <Icon name="clear" />
+          <Icon name="times-circle" />
         </Pill.Addon>
       )}
     </Pill>

--- a/src/components/EasyPill/index.js
+++ b/src/components/EasyPill/index.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Icon from '../Icon';
+import Pill from '../Pill';
+
+export const EasyPill = ({ actions, children, onDelete, ...passedProps }) => {
+  return (
+    <Pill {...passedProps}>
+      {children}
+      {passedProps.checked &&
+        !!actions.length &&
+        actions.map(action => (
+          <Pill.Addon
+            key={action.label}
+            onClick={e => {
+              e.stopPropagation();
+              action.onClick(e);
+            }}
+          >
+            {action.children || action.label}
+          </Pill.Addon>
+        ))}
+      {passedProps.checked && onDelete && (
+        <Pill.Addon
+          onClick={e => {
+            e.stopPropagation();
+            onDelete(e);
+          }}
+        >
+          <Icon name="clear" />
+        </Pill.Addon>
+      )}
+    </Pill>
+  );
+};
+
+EasyPill.propTypes = {
+  actions: PropTypes.arrayOf(
+    PropTypes.shape({
+      children: PropTypes.string,
+      label: PropTypes.string.isRequired,
+      onClick: PropTypes.func.isRequired,
+    })
+  ),
+  checked: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  onDelete: PropTypes.func,
+};
+
+EasyPill.defaultProps = {
+  actions: [],
+  checked: false,
+  onDelete: null,
+};
+
+export default EasyPill;

--- a/src/components/EasyPill/story.js
+++ b/src/components/EasyPill/story.js
@@ -27,6 +27,7 @@ storiesOf('Star Systems/EasyPill', module)
           },
         ]}
         checked={boolean('checked', false)}
+        onClick={action('onClick')}
         onDelete={action('onDelete')}
       >
         EasyPill 1

--- a/src/components/EasyPill/story.js
+++ b/src/components/EasyPill/story.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { boolean } from '@storybook/addon-knobs';
+
+import EasyPill from './';
+import Readme from './README.md';
+
+storiesOf('Star Systems/EasyPill', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => (
+      <EasyPill
+        actions={[
+          {
+            label: 'Boom',
+            onClick: action('Boom'),
+          },
+          {
+            label: 'Bang',
+            onClick: action('Bang'),
+          },
+        ]}
+        checked={boolean('checked', false)}
+        onDelete={action('onDelete')}
+      >
+        EasyPill 1
+      </EasyPill>
+    ),
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  );

--- a/src/components/EasyPill/test.js
+++ b/src/components/EasyPill/test.js
@@ -1,0 +1,81 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import Pill from '../Pill';
+import EasyPill from './';
+
+describe('EasyPill', () => {
+  it('renders', () => {
+    shallow(<EasyPill onDelete={() => {}}>EasyPill</EasyPill>);
+  });
+
+  describe('with children', () => {
+    it('renders its children', () => {
+      const wrapper = mount(
+        <EasyPill onDelete={() => {}}>EasyPill 1</EasyPill>
+      );
+
+      expect(wrapper.children()).toHaveLength(1);
+      expect(wrapper.text()).toEqual('EasyPill 1');
+    });
+  });
+
+  describe('with props.actions', () => {
+    describe('when unchecked', () => {
+      it("doesn't render actions", () => {
+        const wrapper = mount(
+          <EasyPill
+            actions={[
+              {
+                label: 'Boom',
+                onClick: () => {},
+              },
+              {
+                label: 'Bang',
+                onClick: () => {},
+              },
+            ]}
+            onClick={() => {}}
+          >
+            EasyPill 1
+          </EasyPill>
+        );
+
+        // Should use css modules selector, but our version of react-scripts doesn't support it.
+        const addons = wrapper.find(Pill.Addon);
+
+        expect(addons.children()).toHaveLength(0);
+      });
+    });
+
+    describe('when checked', () => {
+      it('does render actions', () => {
+        const wrapper = mount(
+          <EasyPill
+            actions={[
+              {
+                label: 'Boom',
+                onClick: () => {},
+              },
+              {
+                label: 'Bang',
+                onClick: () => {},
+              },
+            ]}
+            checked
+            onClick={() => {}}
+          >
+            EasyPill 1
+          </EasyPill>
+        );
+
+        // Should use css modules selector, but our version of react-scripts doesn't support it.
+        const addons = wrapper.find(Pill.Addon);
+
+        expect(addons).toHaveLength(2);
+        expect(addons.at(0).text()).toEqual('Boom');
+        expect(addons.at(1).text()).toEqual('Bang');
+      });
+    });
+  });
+});

--- a/src/components/Icon/icons/TimesCircle.js
+++ b/src/components/Icon/icons/TimesCircle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ClearIcon = props => {
+const TimesCircle = props => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -18,4 +18,4 @@ const ClearIcon = props => {
   );
 };
 
-export default ClearIcon;
+export default TimesCircle;

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import ClearIcon from './ClearIcon';
+import TimesCircle from './icons/TimesCircle';
 
 export const iconsMap = {
-  clear: ClearIcon,
+  'times-circle': TimesCircle,
 };
 
 const Icon = ({ name, ...passedProps }) =>

--- a/src/components/Icon/story.js
+++ b/src/components/Icon/story.js
@@ -13,7 +13,9 @@ storiesOf('Planets/Icon', module)
       sidebar: IconReadme,
     },
   })
-  .add('Overview', () => <Icon name={select('name', iconNames, 'clear')} />)
+  .add('Overview', () => (
+    <Icon name={select('name', iconNames, 'times-circle')} />
+  ))
   .add('Examples', () => (
     <dl>
       {iconNames.map(iconName => (

--- a/src/components/Icon/test.js
+++ b/src/components/Icon/test.js
@@ -5,7 +5,7 @@ import Icon from './';
 
 describe('Icon', () => {
   it('renders', () => {
-    const wrapper = mount(<Icon name="clear" />);
+    const wrapper = mount(<Icon name="times-circle" />);
 
     expect(wrapper.find('svg').children()).toHaveLength(1);
   });

--- a/src/components/Pill/Addon.js
+++ b/src/components/Pill/Addon.js
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const Addon = props => <div {...props} />;
+
+Addon.displayName = 'PillAddon';
+
+export default Addon;

--- a/src/components/Pill/README.md
+++ b/src/components/Pill/README.md
@@ -1,0 +1,57 @@
+# Pill
+
+Pills are usually small badge-ish, button-ish indicators.
+
+They usually:
+
+- hold a short piece text information
+- appear in lists of similar information
+- are interactive.
+
+Simple pill
+
+```jsx
+<Pill>Tag Name</Pill>
+```
+
+Checked pill, with action
+
+```jsx
+<Pill checked onClick={() => handleOnClick()}>
+  Tag Name
+</Pill>
+```
+
+### Pill.Addon
+
+The `Pill.Addon` is used for `Pill` children other than the text, such as icons. A Pill.Addon may have an independent click area and action associated with it. It can also merely be a visual indicator of selected state (a checkmark, for instance) or a visual reinforcement of the general action associate with a Pill click (a delete icon).
+
+The `Pill.Addon` component can wrap any kind of node.
+It allows the `Pill` to coordinate vertical alignment
+and horizontal margins between the `Pill.Addon`s and their
+siblings with CSS.
+
+Simple pill addon
+
+```jsx
+<Pill>
+  Tag Name
+  <Pill.Addon>{icon}</Pill.Addon>
+</Pill>
+```
+
+Pill, with independent action
+
+```jsx
+<Pill checked onClick={() => handleOnClick()}>
+  Tag Name
+  <Pill.Addon
+    onClick={e => {
+      e.stopPropagation();
+      handleOnClickAddon(e);
+    }}
+  >
+    {icon}
+  </Pill.Addon>
+</Pill>
+```

--- a/src/components/Pill/index.js
+++ b/src/components/Pill/index.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
+import Addon from './Addon';
+import style from './style.css';
+
+const Pill = ({
+  checked,
+  children: initChildren,
+  className,
+  onClick,
+  ...passedProps
+}) => {
+  let children = initChildren;
+
+  children = React.Children.map(initChildren, child =>
+    (child && child.type && child.type.displayName) === Addon.displayName ? (
+      <div className={style.actionInline}>
+        {React.cloneElement(child, { checked })}
+      </div>
+    ) : (
+      child && <span className={style.content}>{child}</span>
+    )
+  );
+
+  const clickableProps = onClick
+    ? {
+        role: 'button',
+        tabIndex: 0,
+        onClick,
+      }
+    : {};
+
+  return (
+    <div
+      {...passedProps}
+      {...clickableProps}
+      className={classNames(style.Pill, className, {
+        [style.checked]: checked,
+      })}
+    >
+      {children}
+    </div>
+  );
+};
+
+Pill.propTypes = {
+  checked: PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+Pill.defaultProps = {
+  checked: false,
+  className: '',
+  onClick: null,
+};
+
+Pill.Addon = Addon;
+
+export default Pill;

--- a/src/components/Pill/story.js
+++ b/src/components/Pill/story.js
@@ -71,7 +71,7 @@ storiesOf('Star Systems/Pill', module)
               action('onClickClear')(e);
             }}
           >
-            <Icon name="clear" />
+            <Icon name="times-circle" />
           </Pill.Addon>
         </Pill>
       </React.Fragment>

--- a/src/components/Pill/story.js
+++ b/src/components/Pill/story.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import Icon from '../Icon';
+import Pill from './';
+import Readme from './README.md';
+
+storiesOf('Star Systems/Pill', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => (
+      <Pill
+        checked={boolean('checked', false)}
+        className={text('className', '')}
+        onClick={action('onClick')}
+      >
+        Pill 1
+      </Pill>
+    ),
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Examples',
+    () => (
+      <React.Fragment>
+        <Pill
+          id="pill-1"
+          onClick={() => action('onClick')('pill-1')}
+          checked
+          style={{ margin: '0 5px 5px 0' }}
+        >
+          Click to fire callback with id argument
+        </Pill>
+        <Pill
+          id="pill-2"
+          onClick={action('onClick')}
+          checked
+          style={{ margin: '0 5px 5px 0' }}
+        >
+          Checked, with Pill.Addon (text)
+          <Pill.Addon
+            onClick={e => {
+              e.stopPropagation();
+              action('onClickEdit')(e);
+            }}
+          >
+            Edit
+          </Pill.Addon>
+        </Pill>
+        <Pill
+          id="pill-3"
+          onClick={action('onClick')}
+          style={{ margin: '0 5px 5px 0' }}
+        >
+          With Pill.Addon (icon)
+          <Pill.Addon
+            onClick={e => {
+              e.stopPropagation();
+              action('onClickClear')(e);
+            }}
+          >
+            <Icon name="clear" />
+          </Pill.Addon>
+        </Pill>
+      </React.Fragment>
+    ),
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  );

--- a/src/components/Pill/style.css
+++ b/src/components/Pill/style.css
@@ -1,0 +1,75 @@
+.Pill {
+  box-sizing: border-box;
+  display: inline-flex;
+  cursor: pointer;
+  outline: none;
+
+  /* Theme stuff */
+  padding: 0 calc(var(--rvr-space-md) - var(--rvr-border-width-base));
+  background-color: var(--rvr-white);
+  border: solid var(--rvr-border-width-base) transparent;
+  border-radius: calc(var(--rvr-line-height-sm) / 2 + var(--rvr-space-sm) - var(--rvr-border-width-base));
+  font-family: var(--rvr-base-font-family);
+  font-size: var(--rvr-font-size-base);
+  line-height: var(--rvr-line-height-sm);
+  color: var(--rvr-light-blue);
+  box-shadow: var(--rvr-box-shadow);
+  transition:
+    background-color 0.2s var(--rvr-easeInOutQuad),
+    color 0.2s var(--rvr-easeInOutQuad),
+    border-color 0.2s var(--rvr-easeInOutQuad);
+}
+
+.Pill:hover {
+  background-color: var(--rvr-rvr-light-blue-hover);
+  color: var(--rvr-white);
+}
+
+.Pill.checked {
+  background-color: #ebfffe;
+  border-color: var(--rvr-light-teal);
+  color: var(--rvr-gray-80);
+  box-shadow: none;
+}
+
+.Pill.checked:hover {
+  background-color: #d5f5f3;
+  border-color: var(--rvr-light-teal-hover);
+  color: var(--rvr-gray-90);
+}
+
+.content {
+  padding: calc(var(--rvr-space-sm) - var(--rvr-border-width-base)) 0;
+}
+
+.actionInline {
+  flex: 0 0 auto;
+  align-self: center;
+  margin: 0 var(--rvr-space-sm);
+  color: var(--rvr-light-blue);
+  transition: color 0.2s var(--rvr-easeInOutQuad);
+}
+
+.actionInline:first-child {
+  margin-inline-start: calc(var(--rvr-space-sm) - var(--rvr-space-md) - var(--rvr-border-width-base));
+}
+
+.actionInline:last-child {
+  margin-inline-end: calc(var(--rvr-space-sm) - var(--rvr-space-md) - var(--rvr-border-width-base));
+}
+
+.actionInline + .actionInline {
+  margin-inline-start: 0;
+}
+
+.Pill:hover .actionInline {
+  color: var(--rvr-white);
+}
+
+.Pill.checked .actionInline {
+  color: var(--rvr-light-teal);
+}
+
+.Pill.checked:hover .actionInline {
+  color: var(--rvr-light-teal-hover);
+}

--- a/src/components/Pill/test.js
+++ b/src/components/Pill/test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount, shallow } from 'enzyme';
+
+import Pill from './';
+
+describe('Pill', () => {
+  it('renders', () => {
+    shallow(<Pill onClick={() => {}}>Pill</Pill>);
+  });
+
+  describe('with non-Addon children', () => {
+    it('renders its children', () => {
+      const wrapper = mount(<Pill onClick={() => {}}>Pill 1</Pill>);
+
+      expect(wrapper.children()).toHaveLength(1);
+      expect(wrapper.text()).toEqual('Pill 1');
+    });
+
+    it('wraps children', () => {
+      const wrapper = mount(<Pill onClick={() => {}}>Pill 1</Pill>);
+      // Should use css modules selector, but our version of react-scripts doesn't support it.
+      const content = wrapper.find('span');
+
+      expect(content).toHaveLength(1);
+      expect(content.text()).toEqual('Pill 1');
+    });
+  });
+
+  describe('with Addon children', () => {
+    it('wraps Addons', () => {
+      const wrapper = mount(
+        <Pill onClick={() => {}}>
+          <Pill.Addon>Foo</Pill.Addon>Pill 1<Pill.Addon>Bar</Pill.Addon>
+        </Pill>
+      );
+
+      // Should use css modules selector, but our version of react-scripts doesn't support it.
+      const addons = wrapper.find('div[role="button"] > div');
+
+      expect(addons).toHaveLength(2);
+      expect(addons.at(0).text()).toEqual('Foo');
+      expect(addons.at(1).text()).toEqual('Bar');
+    });
+  });
+});

--- a/src/components/TabMenu/README.md
+++ b/src/components/TabMenu/README.md
@@ -2,10 +2,10 @@
 
 1. `<TabMenu>` Controls the flex children and alignment of the tab menu. Any styles/classNames and extra props passed will be passed down
 2. `<TabMenu.Item>` Lightly styled inner tab item. `Active` prop automatically adds blue underline, but you will need to add your own padding to the clickable child element (import `itemPadding` for standard padding);
-3. `<SimpleTabMenu>` utilizes both of the above, for an out-of-the-box tab menu
+3. `<EasyTabMenu>` utilizes both of the above, for an out-of-the-box tab menu
 
-## When to use SimpleTabMenu vs customized TabMenu
+## When to use EasyTabMenu vs customized TabMenu
 
-With `SimpleTabMenu`, you pass an array of objects including a key, label, and onClick event, as well as `activeTab` (which corresponds to one of the array item's keys). If you need the tab item to do anything other than a function (eg. be a NavLink) then you can utilize `TabMenu` with `TabMenu.Item` children.
+With `EasyTabMenu`, you pass an array of objects including a key, label, and onClick event, as well as `activeTab` (which corresponds to one of the array item's keys). If you need the tab item to do anything other than a function (eg. be a NavLink) then you can utilize `TabMenu` with `TabMenu.Item` children.
 
 **BONUS** If a child of TabMenu.Item has a className including "active", it will automatically apply the active styling. So, if you do need a list of NavLinks inside the Tab Menus, you shouldn't have to control which one is active!

--- a/src/components/TabMenu/index.js
+++ b/src/components/TabMenu/index.js
@@ -26,11 +26,7 @@ TabMenu.defaultProps = {
   className: '',
 };
 
-/*
- * SimpleComponent naming convention is deprecated due to confusion.
- * Use EasyComponent moving forward.
- */
-export const SimpleTabMenu = ({ tabs, activeTab, size = 'sm', ...props }) => {
+export const EasyTabMenu = ({ tabs, activeTab, size = 'sm', ...props }) => {
   const inner = classNames(style.itemPadding, style[`${size}TextSize`]);
   return (
     <TabMenu {...props}>
@@ -45,9 +41,7 @@ export const SimpleTabMenu = ({ tabs, activeTab, size = 'sm', ...props }) => {
   );
 };
 
-export const EasyTabMenu = SimpleTabMenu;
-
-SimpleTabMenu.propTypes = {
+EasyTabMenu.propTypes = {
   tabs: PropTypes.arrayOf(
     PropTypes.shape({
       key: PropTypes.string.isRequired,
@@ -58,10 +52,17 @@ SimpleTabMenu.propTypes = {
   activeTab: PropTypes.string,
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
 };
-SimpleTabMenu.defaultProps = {
+
+EasyTabMenu.defaultProps = {
   tabs: [],
   activeTab: '',
   size: 'md',
 };
+
+/*
+ * SimpleComponent naming convention is deprecated due to confusion.
+ * Use EasyComponent moving forward.
+ */
+export const SimpleTabMenu = EasyTabMenu;
 
 export default TabMenu;

--- a/src/components/TabMenu/story.js
+++ b/src/components/TabMenu/story.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { text, select, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
-import TabMenu, { SimpleTabMenu, itemPadding } from './';
+import TabMenu, { EasyTabMenu, itemPadding } from './';
 import Readme from './README.md';
 
 storiesOf('Star Systems/TabMenu', module)
@@ -84,7 +84,7 @@ storiesOf('Star Systems/TabMenu/Item', module)
     }
   );
 
-storiesOf('Star Systems/TabMenu/SimpleTabMenu', module)
+storiesOf('Star Systems/TabMenu/EasyTabMenu', module)
   .addParameters({
     readme: {
       sidebar: Readme,
@@ -97,7 +97,7 @@ storiesOf('Star Systems/TabMenu/SimpleTabMenu', module)
     const alignment = select('align', ['left', 'center', 'right'], 'left');
     if (!withContainer) {
       return (
-        <SimpleTabMenu
+        <EasyTabMenu
           align={alignment}
           size={sizeOptions}
           tabs={[
@@ -115,7 +115,7 @@ storiesOf('Star Systems/TabMenu/SimpleTabMenu', module)
     }
     return (
       <div style={{ background: '#ffffff', padding: '0px 20px' }}>
-        <SimpleTabMenu
+        <EasyTabMenu
           style={{ borderBottom: '1px solid #ccc' }}
           align={alignment}
           size={sizeOptions}

--- a/src/components/TabMenu/style.css
+++ b/src/components/TabMenu/style.css
@@ -18,7 +18,7 @@
   justify-content: flex-end;
 }
 
-/* SimpleTabMenu uses these */
+/* EasyTabMenu uses these */
 .itemPadding {
   padding: 16px 0;
 

--- a/src/components/TabMenu/test.js
+++ b/src/components/TabMenu/test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
 
-import TabMenu, { SimpleTabMenu } from './';
+import TabMenu, { EasyTabMenu } from './';
 
 describe('TabMenu', () => {
   it('renders', () => {
@@ -29,10 +29,10 @@ describe('TabMenu.Item', () => {
   });
 });
 
-describe('SimpleTabMenu', () => {
+describe('EasyTabMenu', () => {
   it('has the same number of children as array items', () => {
     const wrapper = shallow(
-      <SimpleTabMenu
+      <EasyTabMenu
         tabs={[
           { key: 'one', label: 'first', onClick: () => {} },
           { key: 'two', label: 'second', onClick: () => {} },

--- a/src/index.js
+++ b/src/index.js
@@ -12,9 +12,14 @@ export { default as Paper } from './components/Paper';
 export { default as Grid } from './components/Grid';
 export { default as Responsive } from './components/Responsive';
 export { default as SideTray } from './components/SideTray';
+
 export {
   default as TabMenu,
   SimpleTabMenu,
   EasyTabMenu,
 } from './components/TabMenu';
+
 export { default as Icon } from './components/Icon';
+export { default as Pill } from './components/Pill';
+export { default as EasyPill } from './components/EasyPill';
+export { default as DeletablePill } from './components/DeletablePill';

--- a/src/shared/colors.css
+++ b/src/shared/colors.css
@@ -53,4 +53,65 @@
 
   /* Notify */
   --rvr-color-notify: var(--rvr-hot-pink);
+
+  /* colors from zeplin styleguide, created by Egle */
+  /* stylelint-disable comment-empty-line-before */
+
+  /* --teal: #00837e; */
+  --rvr-light-blue: #0092c2;
+  --rvr-light-teal: #43bfb7;
+
+  /* --gray-20: #ebeced; */
+
+  /* --orange-hover: #fc5b08;
+  --error: #de4543;
+  --error-hover: #fa6866;
+  --charting-blue-dark: #0177b2;
+  --charting-teal-light: #89ebe8;
+  --warning: #f8ca00;
+  --charting-yellow-base: #fde568;
+  --charting-red-light: #ffa2a7;
+  --charting-blue-light: #65c1ea; */
+  --rvr-rvr-light-blue-hover: #0ba5d6;
+
+  /* --charting-magenta-base: #ff64c6;
+  --charting-green-base: #00c68d;
+  --charting-teal-base: #39dbd8;
+  --charting-yellow-dark: #fdd500;
+  --gray-10: #f7f7f7;
+  --charting-blue-base: #0195de;
+  --charting-green-light: #a1f0d7;
+  --gray-60: #9aa0a5;
+  --charting-red-base: #ff626b; */
+  --rvr-light-teal-hover: #49d1c8;
+
+  /* --charting-purple-base: #8575cd;
+  --success-light: #e9fcf6;
+  --aqua-marine: #44c0c2;
+  --charting-red-dark: #cb4e55;
+  --white: #fff; */
+  --rvr-gray-90: #34404b;
+
+  /* --orange: #e35207;
+  --error-light: #feebea;
+  --charting-teal-dark: #2dafac;
+  --notification: #fc356a;
+  --warning-light: #fef8d3;
+  --medium-blue: #00607f;
+  --charting-green-dark: #009e71; */
+  --rvr-gray-80: #677078;
+
+  /* --success: #63bf52;
+  --light-sky-blue: #d2eef7;
+  --charting-magenta-dark: #cb509e;
+  --charting-purple-dark: #6b5da3;
+  --charting-yellow-light: #fdf5d0;
+  --charting-magenta-light: #ffa4de;
+  --teal-hover: #00a19b;
+  --info-light: #e3f6fc;
+  --gray-40: #cccfd2;
+  --charting-purple-light: #b5ade1;
+  --medium-blue-hover: #007499;
+  --aqua-marine-two: #47cacc; */
+  /* stylelint-enable comment-empty-line-before */
 }

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -26,6 +26,9 @@ import '../components/Paper/story';
  */
 
 import '../components/Bar/story';
+import '../components/Pill/story';
+import '../components/DeletablePill/story';
+import '../components/EasyPill/story';
 import '../components/SideTray/story';
 import '../components/TabMenu/story';
 
@@ -44,8 +47,8 @@ import '../components/TabMenu/story';
 
 import '../components/Grid/story';
 import '../components/Media/story';
-import '../components/Responsive/Grid/story';
 import '../components/Responsive/story';
+import '../components/Responsive/Grid/story';
 
 /*
  * NEW & UNCATEGORIZED


### PR DESCRIPTION
I picked up @andrewBalekha's changes from a couple of weeks ago, and split the `Pill` so there's a very un-opinionated version in addition to one with a built-in delete action.

I also started to stub out an `EasyPill`, but it's not ready for use - the actions and callbacks work, but they need to be put into a dropdown, which doesn't exist in RoverUI yet.