### PR TITLE
Version Bump: 0.1.0-alpha.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.14",
+  "version": "0.1.0-alpha.15",
   "publishConfig": {
-    "tag": "v0.1.0-alpha.14"
+    "tag": "v0.1.0-alpha.15"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",


### PR DESCRIPTION
Somehow I managed to publish `alpha.14` with the `alpha.13` source code. This re-bumps the version number so we can actually have the right code we want.