### PR TITLE
Version Bump: 0.1.0-alpha.16

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ It's _not_ a repository for all shared components. Don't try to add components t
 8. When everything looks good in storybook, run `yarn build` from the root to build the `dist` folder.
 9. From the `example/` directory, run `yarn start`.
 10. That should open a new tab in your browser with an example page that imports the compiled components.
-11. Bump the `package.json`'s version _using [semver](https://semver.org/)_. We're currently in alpha, and probably will be for a while. Versions are cheap.
-12. If all tests look good, submit a pull-request against the master branch through Github. We're using the master branch for now, but by the time we're out of alpha, we'll have a dev branch.
-13. Once you have at least one PR approval from a champion and no pending requests for changes, you can merge in to master.
-14. After merging to master, from your local machine, run `yarn publish` in the root. You'll be prompted for the publish version, which should match the package version.
-15. After publishing, git tag the commit with a `"v"` prefix, e.g. package version `"0.1.0-alpha.8"` becomes `"v0.1.0-alpha.8"`.
-16. Push your tag to the repo
+
+## Publishing a new version
+
+1. Bump the `package.json`'s version _using [semver](https://semver.org/)_. We're currently in alpha, and probably will be for a while. Versions are cheap.
+2. If all tests look good (`yarn test`), submit a pull-request against the master branch through Github. We're using the master branch for now, but by the time we're out of alpha, we'll have a dev branch.
+3. Once you have at least one PR approval from a champion and no pending requests for changes, you can merge in to master.
+4. After merging to master, from your local machine, run `yarn release` in the root. You'll be prompted for the publish version, which should match the package version.
 
 ## Reporting issues
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prepare": "",
     "prepublish": "build",
     "predeploy": "cd example && yarn install && yarn run build",
+    "postpublish": "git tag v$npm_package_version && git push --tags && echo \"Successfully released version $npm_package_version!\"",
     "deploy": "gh-pages -d example/build",
     "storybook": "start-storybook -p 9009",
     "build-storybook": "build-storybook"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.15",
+  "version": "0.1.0-alpha.16",
   "publishConfig": {
-    "tag": "v0.1.0-alpha.15"
+    "tag": "v0.1.0-alpha.16"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",
@@ -52,6 +52,7 @@
     "hygen": "hygen",
     "generate-component": "hygen component new",
     "prepare": "",
+    "prepublish": "build",
     "predeploy": "cd example && yarn install && yarn run build",
     "deploy": "gh-pages -d example/build",
     "storybook": "start-storybook -p 9009",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,10 @@
     "hygen": "hygen",
     "generate-component": "hygen component new",
     "prepare": "",
-    "prepublish": "build",
+    "prepublish": "yarn test && yarn build",
     "predeploy": "cd example && yarn install && yarn run build",
     "postpublish": "git tag v$npm_package_version && git push --tags && echo \"Successfully released version $npm_package_version!\"",
+    "release": "yarn publish . --tag $npm_package_version --no-git-tag-version",
     "deploy": "gh-pages -d example/build",
     "storybook": "start-storybook -p 9009",
     "build-storybook": "build-storybook"

--- a/src/components/Media/test.js
+++ b/src/components/Media/test.js
@@ -18,12 +18,13 @@ describe('Media', () => {
 
     it('renders its children', () => {
       const wrapper = mount(
-        <Media>
-          <Media.Item>Hello</Media.Item>
+        <Media className="media-classname">
+          <Media.Item className="item-classname">Hello</Media.Item>
         </Media>
       );
 
       expect(wrapper.children()).toHaveLength(1);
+      expect(wrapper.find('.media-classname').length).toBeGreaterThan(0);
       expect(wrapper.text()).toEqual('Hello');
     });
   });
@@ -43,11 +44,12 @@ describe('Media', () => {
     it('renders its children', () => {
       const wrapper = mount(
         <Media>
-          <Media.Body>Hello</Media.Body>
+          <Media.Body className="body-classname">Hello</Media.Body>
         </Media>
       );
 
       expect(wrapper.children()).toHaveLength(1);
+      expect(wrapper.find('.body-classname').length).toBeGreaterThan(0);
       expect(wrapper.text()).toEqual('Hello');
     });
   });


### PR DESCRIPTION
Makes several adjustments.

* Prevents publishing node package without building code first. (`yarn prepublish`)
* Adds a `postpublish` hook to add a git tag and push to Github
* Adds the official `yarn release` script that will run tests, build the code, publish the package, and add the appropriate git tag.
* Also updates the `README.md` on how to release a new version