### PR TITLE
EVER-1474 modify sidetray to allow outside click and margin top for header to be visible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "publishConfig": {
-    "tag": "v0.1.0-alpha.17"
+    "tag": "v0.1.0-alpha.18"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",

--- a/src/components/SideTray/README.md
+++ b/src/components/SideTray/README.md
@@ -2,7 +2,7 @@
 
 **A configurable slide-out tray component that automatically triggers onClose when escape key pressed or clicked outside**
 
-This component is used for a full-height dialog box that slides from the right. A <SideTray> can be used on its own (and filled with custom children), but best results are to use the following structure:
+This component is used for a full-height (by default) dialog box that slides from the right. A <SideTray> can be used on its own (and filled with custom children), but best results are to use the following structure:
 
 ```
 <SideTray>
@@ -15,3 +15,5 @@ This component is used for a full-height dialog box that slides from the right. 
 This will result in a header that is always at the top, a footer that is always at the bottom, and a body block that scrolls if the interior content extends outside the height of the parent. If you'd like a header or footer that scrolls with the overflow content, you can easily add that within the <SideTray.Body> component.
 
 Width is currently fixed at 400px but would be great for that to be a prop in the future.
+
+For a SideTray that is not the full height of the viewport, wrapperStyle argument can be used to add padding to the wrapper element. Example, wrapperStyle={{paddingTop: '45px'}} will add 45px of padding above the SideTray (and the backdrop), allowing access to a header.

--- a/src/components/SideTray/index.js
+++ b/src/components/SideTray/index.js
@@ -49,7 +49,7 @@ const SideTray = ({
       <button className={style.backdrop} onClick={onClose} />
     ) : null;
 
-  // Handle custom widths / heights / directions / top margin
+  // Handle custom widths / heights / directions
   const parsedHeight = parseCssSize({ size: height });
   const parsedWidth = parseCssSize({ size: width });
   let hideTransformStyle;

--- a/src/components/SideTray/index.js
+++ b/src/components/SideTray/index.js
@@ -13,10 +13,10 @@ const SideTray = ({
   closeOnOutsideClick,
   direction,
   height,
-  marginTop,
   onClose,
   visible,
   width,
+  wrapperStyle,
   ...passedProps
 }) => {
   // Close tray when the user hits "Escape"
@@ -42,17 +42,11 @@ const SideTray = ({
     };
   }, [visible, onClose]);
 
-  const parsedMarginTop = parseCssSize({ size: marginTop });
-
   // Handle clicking backdrop to close tray
   // TODO: Click and drag from inside to outside the tray shouldn't close it
   const clickOffBackdrop =
     visible && closeOnOutsideClick ? (
-      <button
-        className={style.backdrop}
-        style={{ marginTop: `${parsedMarginTop.size}${parsedMarginTop.unit}` }}
-        onClick={onClose}
-      />
+      <button className={style.backdrop} onClick={onClose} />
     ) : null;
 
   // Handle custom widths / heights / directions / top margin
@@ -67,7 +61,6 @@ const SideTray = ({
     right: 0,
     top: 0,
     width: `${parsedWidth.size}${parsedWidth.unit}`,
-    marginTop: `${parsedMarginTop.size}${parsedMarginTop.unit}`,
   };
 
   switch (direction) {
@@ -91,20 +84,28 @@ const SideTray = ({
   }
 
   return (
-    <React.Fragment>
-      <div
-        {...passedProps}
-        style={{
-          ...sideTrayStyles,
-          ...(!visible ? { transform: hideTransformStyle } : {}),
-          ...passedProps.style,
-        }}
-        className={`${style.SideTray} ${className}`}
-      >
-        <div className={style.container}>{children}</div>
+    <div
+      className={style.wrapper}
+      style={{
+        ...wrapperStyle,
+        ...(!visible ? { display: 'none' } : {}),
+      }}
+    >
+      <div className={style.container}>
+        <div
+          {...passedProps}
+          style={{
+            ...sideTrayStyles,
+            ...(!visible ? { transform: hideTransformStyle } : {}),
+            ...passedProps.style,
+          }}
+          className={`${style.SideTray} ${className}`}
+        >
+          <div className={style.content}>{children}</div>
+        </div>
+        {clickOffBackdrop}
       </div>
-      {clickOffBackdrop}
-    </React.Fragment>
+    </div>
   );
 };
 
@@ -114,11 +115,11 @@ SideTray.propTypes = {
   closeOnOutsideClick: PropTypes.bool,
   direction: PropTypes.oneOf(['t', 'r', 'b', 'l']),
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  marginTop: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onClose: PropTypes.func.isRequired,
   style: PropTypes.object,
   visible: PropTypes.bool,
   width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  wrapperStyle: PropTypes.object,
 };
 
 SideTray.defaultProps = {
@@ -126,10 +127,10 @@ SideTray.defaultProps = {
   closeOnOutsideClick: true,
   direction: 'r',
   height: '100vh',
-  marginTop: '0px',
   style: {},
   visible: false,
   width: '400px',
+  wrapperStyle: {},
 };
 
 const Header = props => (

--- a/src/components/SideTray/index.js
+++ b/src/components/SideTray/index.js
@@ -10,8 +10,10 @@ import style from './style.css';
 const SideTray = ({
   children,
   className,
+  closeOnOutsideClick,
   direction,
   height,
+  marginTop,
   onClose,
   visible,
   width,
@@ -40,13 +42,20 @@ const SideTray = ({
     };
   }, [visible, onClose]);
 
+  const parsedMarginTop = parseCssSize({ size: marginTop });
+
   // Handle clicking backdrop to close tray
   // TODO: Click and drag from inside to outside the tray shouldn't close it
-  const clickOffBackdrop = visible ? (
-    <button className={style.backdrop} onClick={onClose} />
-  ) : null;
+  const clickOffBackdrop =
+    visible && closeOnOutsideClick ? (
+      <button
+        className={style.backdrop}
+        style={{ marginTop: `${parsedMarginTop.size}${parsedMarginTop.unit}` }}
+        onClick={onClose}
+      />
+    ) : null;
 
-  // Handle custom widths / heights / directions
+  // Handle custom widths / heights / directions / top margin
   const parsedHeight = parseCssSize({ size: height });
   const parsedWidth = parseCssSize({ size: width });
   let hideTransformStyle;
@@ -58,6 +67,7 @@ const SideTray = ({
     right: 0,
     top: 0,
     width: `${parsedWidth.size}${parsedWidth.unit}`,
+    marginTop: `${parsedMarginTop.size}${parsedMarginTop.unit}`,
   };
 
   switch (direction) {
@@ -101,8 +111,10 @@ const SideTray = ({
 SideTray.propTypes = {
   children: PropTypes.node.isRequired,
   className: PropTypes.string,
+  closeOnOutsideClick: PropTypes.bool,
   direction: PropTypes.oneOf(['t', 'r', 'b', 'l']),
   height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  marginTop: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onClose: PropTypes.func.isRequired,
   style: PropTypes.object,
   visible: PropTypes.bool,
@@ -111,8 +123,10 @@ SideTray.propTypes = {
 
 SideTray.defaultProps = {
   className: '',
+  closeOnOutsideClick: true,
   direction: 'r',
   height: '100vh',
+  marginTop: '0px',
   style: {},
   visible: false,
   width: '400px',

--- a/src/components/SideTray/style.css
+++ b/src/components/SideTray/style.css
@@ -1,6 +1,6 @@
 .SideTray {
   background-color: var(--rvr-white);
-  position: fixed;
+  position: absolute;
   transition: transform 0.3s var(--rvr-slideout);
   overflow: auto;
   z-index: var(--rvr-zindex-sidetray);
@@ -8,7 +8,22 @@
   transform: translate3d(0, 0, 0);
 }
 
+.wrapper {
+  height: 100vh;
+  width: 100vw;
+  box-sizing: border-box;
+  position: fixed;
+  top: 0;
+  left: 0;
+}
+
 .container {
+  width: 100%;
+  height: 100%;
+  position: fixed;
+}
+
+.content {
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -19,12 +34,12 @@
   visibility: visible;
   border: none;
   user-select: none;
-  position: fixed;
+  position: absolute;
   top: 0;
   right: 0;
   bottom: 0;
   left: 0;
-  height: 100vh;
+  height: 100%;
   width: 100vw;
   z-index: var(--rvr-zindex-sidetray-backdrop);
   background-color: rgba(0, 0, 0, 0.3);

--- a/src/components/SideTray/test.js
+++ b/src/components/SideTray/test.js
@@ -14,34 +14,23 @@ describe('SideTray', () => {
     expect(wrapper.text()).toEqual('Hey I am a sidetray!');
   });
 
-  it('renders correctly with marginTop set', () => {
+  it('correctly sets wrapperStyle', () => {
     const wrapper = mount(
-      <SideTray visible onClose={() => {}} marginTop="45px">
+      <SideTray
+        visible
+        onClose={() => {}}
+        wrapperStyle={{ paddingTop: '45px' }}
+      >
         I am a sidetray with marginTop!
       </SideTray>
     );
-    const backdrop = wrapper.find('button');
-
-    expect(backdrop.prop('style')).toEqual({ marginTop: '45px' });
-    expect(wrapper.html()).toContain('margin-top: 45px;');
-  });
-
-  it('defaults marginTop to 0', () => {
-    const wrapper = mount(
-      <SideTray visible onClose={() => {}}>
-        I am a sidetray with marginTop!
-      </SideTray>
-    );
-    const backdrop = wrapper.find('button');
-
-    expect(backdrop.prop('style')).toEqual({ marginTop: '0px' });
-    expect(wrapper.html()).toContain('margin-top: 0px;');
+    expect(wrapper.html()).toContain('padding-top: 45px;');
   });
 
   it('does not include backdrop if closeOnOutsideClick is false', () => {
     const wrapper = mount(
       <SideTray visible onClose={() => {}} closeOnOutsideClick={false}>
-        I am a sidetray with marginTop!
+        I am a sidetray that does not close on outside click!
       </SideTray>
     );
 

--- a/src/components/SideTray/test.js
+++ b/src/components/SideTray/test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import SideTray from './';
 
@@ -12,5 +12,39 @@ describe('SideTray', () => {
     );
 
     expect(wrapper.text()).toEqual('Hey I am a sidetray!');
+  });
+
+  it('renders correctly with marginTop set', () => {
+    const wrapper = mount(
+      <SideTray visible onClose={() => {}} marginTop="45px">
+        I am a sidetray with marginTop!
+      </SideTray>
+    );
+    const backdrop = wrapper.find('button');
+
+    expect(backdrop.prop('style')).toEqual({ marginTop: '45px' });
+    expect(wrapper.html()).toContain('margin-top: 45px;');
+  });
+
+  it('defaults marginTop to 0', () => {
+    const wrapper = mount(
+      <SideTray visible onClose={() => {}}>
+        I am a sidetray with marginTop!
+      </SideTray>
+    );
+    const backdrop = wrapper.find('button');
+
+    expect(backdrop.prop('style')).toEqual({ marginTop: '0px' });
+    expect(wrapper.html()).toContain('margin-top: 0px;');
+  });
+
+  it('does not include backdrop if closeOnOutsideClick is false', () => {
+    const wrapper = mount(
+      <SideTray visible onClose={() => {}} closeOnOutsideClick={false}>
+        I am a sidetray with marginTop!
+      </SideTray>
+    );
+
+    expect(wrapper.contains(<button />)).toBe(false);
   });
 });


### PR DESCRIPTION
<img width="2032" alt="Screen Shot 2019-08-19 at 11 57 17 AM" src="https://user-images.githubusercontent.com/5022676/63284161-9436e380-c278-11e9-88f9-438097872b75.png">
<img width="2032" alt="Screen Shot 2019-08-19 at 11 57 14 AM" src="https://user-images.githubusercontent.com/5022676/63284162-9436e380-c278-11e9-83a2-7d479d1d6e87.png">

Changes: adds new arguments for the SideTray to allow for marginTop & have no backdrop/close on outside click. These new requirements for the sidetray will be used in a handfull of other areas throughout the application.

Risk: low, small isolated changes to SideTray
