### PR TITLE
Add and fix tests for Avatar and Button

### DIFF
--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -50,10 +50,14 @@ const Avatar = ({
   const image = useMemo(() => {
     if (!imageUrl) return null;
     // Only load the image if the url response is 200
-    const http = new XMLHttpRequest();
-    http.open('HEAD', imageUrl, false);
-    http.send();
-    return http.status === 200 ? imageUrl : null;
+    try {
+      const http = new XMLHttpRequest();
+      http.open('HEAD', imageUrl, false);
+      http.send();
+      return http.status === 200 ? imageUrl : null;
+    } catch (e) {
+      return null;
+    }
   }, [imageUrl]);
 
   const mainStyle = {

--- a/src/components/Avatar/test.js
+++ b/src/components/Avatar/test.js
@@ -23,4 +23,22 @@ describe('Avatar', () => {
     expect(wrapper.prop('style')).toHaveProperty('width', '67px');
     expect(wrapper.prop('style')).toHaveProperty('height', '67px');
   });
+
+  it('renders initials of the image url results in non-200 response', () => {
+    const wrapper = shallow(
+      <Avatar name="Helter Skelter" imageUrl="https://picsum.photos/wrong" />
+    );
+    expect(wrapper.text()).toEqual('HS');
+  });
+
+  it('renders an image in bg assuming valid url', () => {
+    const wrapper = shallow(
+      <Avatar name="Helter Skelter" imageUrl="https://picsum.photos/60" />
+    );
+    expect(wrapper.text()).toEqual('');
+    expect(wrapper.prop('style')).toHaveProperty(
+      'backgroundImage',
+      'url(https://picsum.photos/60)'
+    );
+  });
 });

--- a/src/components/Button/Addon/test.js
+++ b/src/components/Button/Addon/test.js
@@ -6,12 +6,12 @@ import Addon from './';
 describe('Addon', () => {
   describe('Main component', () => {
     it('renders an `Addon` tag without error', () => {
-      shallow(<Addon />);
+      shallow(<Addon size="sm" />);
     });
 
     describe('props.className', () => {
       it('adds custom className', () => {
-        const wrapper = shallow(<Addon className="foo" />);
+        const wrapper = shallow(<Addon className="foo" size="sm" />);
         expect(wrapper.hasClass('foo')).toEqual(true);
       });
     });


### PR DESCRIPTION
Added more substantial tests for Avatar. Was throwing some proptype errors for size on Addon, which is a required proptype but not supplied in the tests. Not sure if it should actually be required or have a default value, open to feedback there (and everywhere)