### PR TITLE
Reduce specificity of checked Pill selector, and...

### DIFF
--- a/src/components/Button/Addon/index.js
+++ b/src/components/Button/Addon/index.js
@@ -13,11 +13,12 @@ const Addon = ({ className, size, ...passedProps }) => (
 
 Addon.propTypes = {
   className: PropTypes.string,
-  size: PropTypes.oneOf(['sm', 'md', 'lg']).isRequired,
+  size: PropTypes.oneOf(['sm', 'md', 'lg']),
 };
 
 Addon.defaultProps = {
   className: '',
+  size: 'md',
 };
 
 Addon.displayName = 'ButtonAddon';

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -5,6 +5,8 @@
   font-size: var(--rvr-font-size-md);
   line-height: var(--rvr-line-height-sm);
   transition: 0.2s linear background-color, 0.2s linear border-color, 0.2s linear color;
+  display: inline-flex;
+  flex-flow: row nowrap;
   align-content: center;
 }
 

--- a/src/components/Pill/style.css
+++ b/src/components/Pill/style.css
@@ -25,14 +25,14 @@
   color: var(--rvr-white);
 }
 
-.Pill.checked {
+.checked {
   background-color: #ebfffe;
   border-color: var(--rvr-light-teal);
   color: var(--rvr-gray-80);
   box-shadow: none;
 }
 
-.Pill.checked:hover {
+.checked:hover {
   background-color: #d5f5f3;
   border-color: var(--rvr-light-teal-hover);
   color: var(--rvr-gray-90);
@@ -62,14 +62,14 @@
   margin-inline-start: 0;
 }
 
+.checked .actionInline {
+  color: var(--rvr-light-teal);
+}
+
 .Pill:hover .actionInline {
   color: var(--rvr-white);
 }
 
-.Pill.checked .actionInline {
-  color: var(--rvr-light-teal);
-}
-
-.Pill.checked:hover .actionInline {
+.checked:hover .actionInline {
   color: var(--rvr-light-teal-hover);
 }


### PR DESCRIPTION
* Made the `Addon`'s size prop optional (fixes a proptypes error in a test).
* Made `Button` `display: inline-flex` initially. Before doing this I looked for usages in the consuming Cision front-end app, only found one, and manually checked that the style changes didn't break anything in Chrome with dev tools.