### PR TITLE
Fixes #111 by adding storybook publish to the npm postpublish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "prepare": "",
     "prepublish": "yarn test && yarn build",
     "predeploy": "cd example && yarn install && yarn run build",
-    "postpublish": "git tag v$npm_package_version && git push --tags && echo \"Successfully released version $npm_package_version!\"",
+    "postpublish": "git tag v$npm_package_version && git push --tags && echo \"Successfully released version $npm_package_version!\" && yarn deploy:storybook",
     "release": "yarn publish --no-git-tag-version",
     "deploy": "gh-pages -d docs",
     "storybook": "start-storybook -p 9009",


### PR DESCRIPTION
Need to actually test this next time we deploy a new version to npm, but it should work.