### PR TITLE
Correctly setup re-renders for performance

### DIFF
--- a/src/components/Media/test.js
+++ b/src/components/Media/test.js
@@ -1,7 +1,28 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { mount } from 'enzyme';
 
 import Media from './';
+
+const TestWrapper = () => {
+  const [val, setVal] = useState('');
+
+  const handleOnChange = e => {
+    setVal(e.target.value);
+  };
+
+  return (
+    <Media>
+      <Media.Body id="media-body">
+        <input
+          id="input-test"
+          type="text"
+          value={val}
+          onChange={handleOnChange}
+        />
+      </Media.Body>
+    </Media>
+  );
+};
 
 describe('Media', () => {
   describe('Media.Item', () => {
@@ -14,6 +35,18 @@ describe('Media', () => {
 
       expect(wrapper.find('main')).toHaveLength(1);
       expect(wrapper.find('main aside')).toHaveLength(1);
+    });
+
+    it('will not re-render everything unnecessarily', () => {
+      const wrapper = mount(<TestWrapper />);
+      const input = wrapper.find('input#input-test');
+
+      input.instance().focus();
+
+      input.simulate('change', { target: { value: 'h' } });
+      input.simulate('change', { target: { value: 'he' } });
+
+      expect(input.is(':focus')).toBe(true);
     });
 
     it('renders its children', () => {

--- a/src/components/withDefaultTheme/index.js
+++ b/src/components/withDefaultTheme/index.js
@@ -3,11 +3,11 @@ import { withTheme } from 'styled-components';
 import defaultTheme from '../../shared/theme';
 
 const withDefaultTheme = WrappedComponent => {
-  const Themed = props =>
-    React.createElement(withTheme(WrappedComponent), {
-      ...props,
-      theme: { ...defaultTheme },
-    });
+  const ThemedComponent = withTheme(WrappedComponent);
+
+  const Themed = props => (
+    <ThemedComponent {...props} theme={{ ...defaultTheme }} />
+  );
 
   Themed.displayName = `Themed(${WrappedComponent.displayName ||
     WrappedComponent.name ||


### PR DESCRIPTION
When trying to setup an `<input />` with value state wrapped inside of a themed component, the entire tree inside of the themed components would re-render. For example:

```jsx
const Test = () => {
  const [val, setVal] = useState('');
  return (
    <Media>
      <input type="text" value={val} onChange={e => setVal(e.target.value)} />
    </Media>
  );
};
```

When a user changed the value of the text input, the entire `Media` tree would re-render. Thanks to one small change to `withDefaultTheme`, this no longer happens and the added test for `Media` ensures that this regression will not occur again.