### PR TITLE
Version Bump: v0.1.0-alpha.25

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.24",
+  "version": "0.1.0-alpha.25",
   "publishConfig": {
-    "tag": "v0.1.0-alpha.24"
+    "tag": "v0.1.0-alpha.25"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",


### PR DESCRIPTION
Provides the bugfix to eliminate unnecessary re-renders of entire DOM trees for small state changes.