### PR TITLE
Version Bump: v0.1.0-alpha.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "0.1.0-alpha.25",
+  "version": "0.1.0-alpha.26",
   "publishConfig": {
-    "tag": "v0.1.0-alpha.25"
+    "tag": "v0.1.0-alpha.26"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",


### PR DESCRIPTION
#### Changes: 

* Removes `styled-component` from `Paper` and `Badge` components for simpler dependencies.

#### Breaking changes

* `styled-system` properties such as `<Paper p={0}>` will no longer work. The `p` attribute was part of styled system. These theme-related attributes will no longer be supported. Moving forward any use of `Paper` that requires style changes other than through the provided prop flags will need to be done through `className` or `style` props. There are only a small handful (4-5) of places in the main FE application that use these properties since we have bene favoring any styling through `className` and/or `style`. I've already identified them and prepared for this switch out so this will not be a major issue
* `<Badge>` from Rover was not yet used in the main FE app, so as far our app is concerned this is not an issue