### PR TITLE
Added Button level 'text' and added yalc note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,18 @@ It's _not_ a repository for all shared components. Don't try to add components t
 9. From the `example/` directory, run `yarn start`.
 10. That should open a new tab in your browser with an example page that imports the compiled components.
 
+### Testing another project using local RoverUI
+
+For simple projects, you should be able to use [`npm link`](https://docs.npmjs.com/cli/link.html) or [`yarn link`](https://yarnpkg.com/lang/en/docs/cli/link/) to temporarily and invisibly load your local copy of RoverUI as a dependency in another project. These tools both have caveats, though. They may fail on peer dependencies, and their symlinking strategy can introduce bugs in monorepos with multiple workspaces.
+
+**Experimental**
+
+You can use [yalc](https://github.com/whitecolor/yalc) to test a local project. It copies files instead of symlinking them.
+
+1. In the RoverUI project directory, use `yalc publish --force`. Using `--force` is important because it skips the publish scripts, so it won't try to connect to npm.
+2. In the target project directory, use `yalc add @cision/rover-ui --no-pure`. Using `--no-pure-` seems to be important if you're working in a monorepo with multiple workspaces, but _it will edit your consuming project's `package.json` file and add a `.yalc` folder and `yalc.lock`. **Don't forget to revert those changes when you're finished.**_
+3. You should be able to import RoverUI components in your target project normally now.
+
 ## Publishing a new version
 
 To publish the npm package, you'll need a free account on npmjs.com, and you'll need to be added to the list of maintainers by one of the current RoverUI maintainers.

--- a/example/package.json
+++ b/example/package.json
@@ -8,7 +8,7 @@
     "prop-types": "link:../node_modules/prop-types",
     "react": "link:../node_modules/react",
     "react-dom": "link:../node_modules/react-dom",
-    "react-scripts": "link:../node_modules/react-scripts",
+    "react-scripts": "^1.1.4",
     "@cision/rover-ui": "link:../"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "publishConfig": {
-    "tag": "v1.1.1"
+    "tag": "v1.2.0"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -10,6 +10,7 @@ import style from './style.css';
 
 const Button = props => {
   const {
+    active,
     children: initChildren,
     className: passedClassName,
     darkMode,
@@ -28,6 +29,7 @@ const Button = props => {
     style[size],
     {
       [style.darkMode]: darkMode,
+      [style.active]: active,
     }
   );
 
@@ -56,23 +58,38 @@ const Button = props => {
   );
 };
 
+export const levels = [
+  'primary',
+  'secondary',
+  'success',
+  'teal',
+  'tertiary',
+  'link',
+  'text',
+];
+
+export const states = [
+  'checked',
+  'active',
+  'disabled',
+  'hover',
+  'focus',
+];
+
+export const sizes = ['sm', 'md', 'lg'];
+
 Button.propTypes = {
+  active: PropTypes.bool,
   children: PropTypes.node,
   className: PropTypes.string,
   darkMode: PropTypes.bool,
-  level: PropTypes.oneOf([
-    'primary',
-    'teal',
-    'secondary',
-    'success',
-    'tertiary',
-    'teal',
-  ]),
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
+  level: PropTypes.oneOf(levels),
+  size: PropTypes.oneOf(sizes),
   tag: tagPropTypes,
 };
 
 Button.defaultProps = {
+  active: false,
   children: null,
   className: '',
   darkMode: false,

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,19 +1,52 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import { propTypes as tagPropTypes } from '../../shared/models/tag';
 
 import Addon from './Addon';
+import styles from './style.css';
 
-import style from './style.css';
+/*
+  These 2 variants are in design docs but might not be "Buttons" in a strict sense.
+  Filter (-> Should probably be a pill)
+  Select (-> These might be better served as a different component)
+*/
+
+// Design doc names in comments
+export const levels = [
+  'primary', // "Primary"
+  'primary-alt', // "Teal"
+  'secondary', // "Secondary"
+  'tertiary', // "Tertiary"
+  'success', // "Green"
+  'danger', // "Red"
+  'link', // "Blue"
+  'text', // "Gray"
+];
+
+// These states are each their own boolean prop
+export const states = [
+  'hover', // "Hover"
+  'focus', // "Focus"
+  'active', // "Pressed"
+  'disabled', // "Disabled"
+  'checked', // "Active"
+];
+
+export const sizes = [
+  'sm', // ""
+  'md', // "Medium"
+  'lg', // "Large"
+];
 
 const Button = props => {
   const {
-    active,
     children: initChildren,
+    circle,
     className: passedClassName,
     darkMode,
+    hollow,
     level,
     size,
     tag: Tag,
@@ -22,15 +55,49 @@ const Button = props => {
 
   let children = initChildren;
 
-  const className = classNames(
-    passedClassName,
-    style.Button,
-    style[level],
-    style[size],
-    {
-      [style.darkMode]: darkMode,
-      [style.active]: active,
-    }
+  // For future ref
+  const truthyStateKeys = useMemo(
+    () => states.filter(state => !!passedProps[state]),
+    [passedProps]
+  );
+
+  // Filter out undefined passedProps and `active` from DOM element tags
+  const safePassedProps = useMemo(
+    () =>
+      Object.entries(passedProps).reduce((result, [key, value]) => {
+        if (value === undefined) {
+          return result;
+        }
+
+        if (typeof Tag === 'string' && key === 'active') {
+          return result;
+        }
+
+        return { ...result, [key]: value };
+      }, {}),
+    [passedProps, Tag]
+  );
+
+  const className = useMemo(
+    () =>
+      classNames(
+        passedClassName,
+        styles.Button,
+        styles[level],
+        styles[size],
+        {
+          [styles.hollow]: hollow || darkMode,
+          [styles.circle]: circle,
+          [styles['primary-alt']]: level === 'teal', // For backwards compatibility with the old level name
+        },
+        /*
+          In addition to "real" boolean props, this adds class names for
+          'disabled', 'active', etc. so consumers can force appearance on
+          elements easily
+        */
+        truthyStateKeys.map(truthyStateKey => styles[truthyStateKey])
+      ),
+    [circle, darkMode, hollow, level, passedClassName, size, truthyStateKeys]
   );
 
   const addonChildren = React.Children.toArray(initChildren).filter(
@@ -52,50 +119,51 @@ const Button = props => {
   }
 
   return (
-    <Tag {...passedProps} className={className}>
+    <Tag {...safePassedProps} className={className}>
       {children}
     </Tag>
   );
 };
 
-export const levels = [
-  'primary',
-  'secondary',
-  'success',
-  'teal',
-  'tertiary',
-  'link',
-  'text',
-];
-
-export const states = [
-  'checked',
-  'active',
-  'disabled',
-  'hover',
-  'focus',
-];
-
-export const sizes = ['sm', 'md', 'lg'];
-
 Button.propTypes = {
   active: PropTypes.bool,
   children: PropTypes.node,
+  /** `circle` buttons have a fixed width === height */
+  circle: PropTypes.bool,
   className: PropTypes.string,
+  /** `darkMode` is deprecated in favor of `hollow` */
   darkMode: PropTypes.bool,
+  /** `hollow` buttons have an outline style, and are suitable for dark backgrounds */
+  hollow: PropTypes.bool,
   level: PropTypes.oneOf(levels),
   size: PropTypes.oneOf(sizes),
   tag: tagPropTypes,
+  ...states.reduce(
+    (result, stateKey) => ({
+      ...result,
+      [stateKey]: PropTypes.bool,
+    }),
+    {}
+  ),
 };
 
 Button.defaultProps = {
   active: false,
   children: null,
+  circle: undefined,
   className: '',
   darkMode: false,
+  hollow: false,
   level: 'secondary',
   size: 'lg',
   tag: 'button',
+  ...states.reduce(
+    (result, stateKey) => ({
+      ...result,
+      [stateKey]: undefined,
+    }),
+    {}
+  ),
 };
 
 Button.Addon = Addon;

--- a/src/components/Button/story.js
+++ b/src/components/Button/story.js
@@ -5,7 +5,8 @@ import { boolean, text, select } from '@storybook/addon-knobs';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import Button, { levels, sizes } from './';
+import Icon from '../Icon';
+import Button, { levels, sizes, states } from './';
 import ButtonReadme from './README.md';
 import AddonReadme from './Addon/README.md';
 
@@ -30,7 +31,8 @@ storiesOf('Planets/Button', module)
       <Button
         active={boolean('active', false)}
         className={text('className', '')}
-        darkMode={boolean('darkMode', false)}
+        circle={boolean('circle', false)}
+        hollow={boolean('hollow', false)}
         disabled={boolean('disabled', false)}
         href={select('tag', tags, 'button') === 'a' ? '#' : null}
         level={select('level', levels, 'secondary')}
@@ -55,88 +57,152 @@ storiesOf('Planets/Button', module)
   .add(
     'Examples',
     () => {
-      const sections = levels.map(level => {
-        return (
-          <div>
-            <h2>{level}</h2>
-            {sizes.map(size => {
-              return (
-                <div style={{ marginBottom: '20px' }}>
-                  <span style={{ marginRight: '20px' }}>{size}</span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button level={level} onClick={() => {}} size={size}>
-                      Normal
-                    </Button>
-                  </span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button level={level} onClick={() => {}} size={size}>
-                      <Button.Addon>
-                        <span role="img" aria-label="Rocket">
-                          🚀
-                        </span>
-                      </Button.Addon>
-                      With addon
-                    </Button>
-                  </span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button active level={level} onClick={() => {}} size={size}>
-                      Hover
-                    </Button>
-                  </span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button
-                      disabled
-                      level={level}
-                      onClick={() => {}}
-                      size={size}
-                    >
-                      Disabled
-                    </Button>
-                  </span>
-                </div>
-              );
-            })}
-          </div>
-        );
-      });
-
       return (
         <div>
-          {sections}
-          <div style={{ background: 'black', color: 'white', padding: '1em' }}>
-            <h2>darkMode</h2>
-            {sizes.map(size => {
-              return (
+          <h2>Sizes</h2>
+          <div style={{ marginBottom: '20px' }}>
+            {sizes.map(size => (
+              <span
+                key={size}
+                style={{
+                  display: 'inline-block',
+                  marginRight: '20px',
+                  marginBottom: '10px',
+                }}
+              >
+                <Button size={size}>
+                  {size !== Button.defaultProps.size
+                    ? size
+                    : `${size} (default)`}
+                </Button>
+              </span>
+            ))}
+          </div>
+          <hr />
+          <h2>Tags</h2>
+          <div style={{ marginBottom: '20px' }}>
+            <span
+              style={{
+                display: 'inline-block',
+                marginRight: '20px',
+                marginBottom: '10px',
+              }}
+            >
+              <Button href="#" tag="a">
+                a
+              </Button>
+            </span>
+            <span
+              style={{
+                display: 'inline-block',
+                marginRight: '20px',
+                marginBottom: '10px',
+              }}
+            >
+              <Button tag="button">button (default)</Button>
+            </span>
+            <span
+              style={{
+                display: 'inline-block',
+                marginRight: '20px',
+                marginBottom: '10px',
+              }}
+            >
+              <Button tag="input" type="button" value="input" />
+            </span>
+          </div>
+          <hr />
+          <h2>Add-ons</h2>
+          <div style={{ marginBottom: '20px' }}>
+            <Button>
+              <Button.Addon>
+                <Icon
+                  fill="currentColor"
+                  height="16"
+                  name="check"
+                  style={{ display: 'block' }}
+                  width="16"
+                />
+              </Button.Addon>
+              With left addon
+            </Button>
+          </div>
+          <hr />
+          <h2>Circle</h2>
+          <div style={{ marginBottom: '20px' }}>
+            {sizes.map(size => (
+              <span
+                key={size}
+                style={{
+                  display: 'inline-block',
+                  marginRight: '20px',
+                  marginBottom: '10px',
+                }}
+              >
+                <Button circle size={size}>
+                  <Icon
+                    fill="currentColor"
+                    height="16"
+                    name="check"
+                    style={{ display: 'block' }}
+                    width="16"
+                  />
+                </Button>
+              </span>
+            ))}
+          </div>
+          <hr />
+          <h2>Levels</h2>
+          {levels.map(level => {
+            return (
+              <div key={level}>
+                <h3>{level}</h3>
                 <div style={{ marginBottom: '20px' }}>
-                  <span style={{ marginRight: '20px' }}>{size}</span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button darkMode onClick={() => {}} size={size}>
-                      Normal
-                    </Button>
+                  <span
+                    style={{
+                      display: 'inline-block',
+                      marginRight: '20px',
+                      marginBottom: '10px',
+                    }}
+                  >
+                    <Button level={level}>default</Button>
                   </span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button darkMode onClick={() => {}} size={size}>
-                      <Button.Addon>
-                        <span role="img" aria-label="Rocket">
-                          🚀
-                        </span>
-                      </Button.Addon>
-                      With addon
-                    </Button>
-                  </span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button active darkMode onClick={() => {}} size={size}>
-                      Hover
-                    </Button>
-                  </span>
-                  <span style={{ marginRight: '20px' }}>
-                    <Button darkMode disabled onClick={() => {}} size={size}>
-                      Disabled
-                    </Button>
-                  </span>
+                  {states.map(state => (
+                    <span key={state} style={{ marginRight: '20px' }}>
+                      <Button level={level} {...{ [state]: true }}>
+                        {state}
+                      </Button>
+                    </span>
+                  ))}
                 </div>
-              );
-            })}
+              </div>
+            );
+          })}
+          <hr />
+          <h2>Hollow</h2>
+          <div
+            style={{
+              background: 'black',
+              padding: '20px',
+              marginBottom: '20px',
+            }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                marginRight: '20px',
+                marginBottom: '10px',
+              }}
+            >
+              <Button hollow>(default)</Button>
+            </span>
+            {states.map(state => (
+              <span key={state} style={{ marginRight: '20px' }}>
+                <Button hollow {...{ [state]: true }}>
+                  {state}
+                </Button>
+              </span>
+            ))}
           </div>
         </div>
       );

--- a/src/components/Button/story.js
+++ b/src/components/Button/story.js
@@ -5,12 +5,9 @@ import { boolean, text, select } from '@storybook/addon-knobs';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import Button from './';
+import Button, { levels, sizes } from './';
 import ButtonReadme from './README.md';
 import AddonReadme from './Addon/README.md';
-
-const levels = ['tertiary', 'teal', 'secondary', 'primary'];
-const sizes = ['sm', 'md', 'lg'];
 
 const MyComponent = props => (
   <button {...props} className={classNames(props.className, 'MyComponent')} />
@@ -31,6 +28,7 @@ storiesOf('Planets/Button', module)
     'Overview',
     () => (
       <Button
+        active={boolean('active', false)}
         className={text('className', '')}
         darkMode={boolean('darkMode', false)}
         disabled={boolean('disabled', false)}
@@ -47,6 +45,102 @@ storiesOf('Planets/Button', module)
         {text('children', 'Click me!')}
       </Button>
     ),
+    {
+      info: {
+        inline: false,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Examples',
+    () => {
+      const sections = levels.map(level => {
+        return (
+          <div>
+            <h2>{level}</h2>
+            {sizes.map(size => {
+              return (
+                <div style={{ marginBottom: '20px' }}>
+                  <span style={{ marginRight: '20px' }}>{size}</span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button level={level} onClick={() => {}} size={size}>
+                      Normal
+                    </Button>
+                  </span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button level={level} onClick={() => {}} size={size}>
+                      <Button.Addon>
+                        <span role="img" aria-label="Rocket">
+                          🚀
+                        </span>
+                      </Button.Addon>
+                      With addon
+                    </Button>
+                  </span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button active level={level} onClick={() => {}} size={size}>
+                      Hover
+                    </Button>
+                  </span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button
+                      disabled
+                      level={level}
+                      onClick={() => {}}
+                      size={size}
+                    >
+                      Disabled
+                    </Button>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        );
+      });
+
+      return (
+        <div>
+          {sections}
+          <div style={{ background: 'black', color: 'white', padding: '1em' }}>
+            <h2>darkMode</h2>
+            {sizes.map(size => {
+              return (
+                <div style={{ marginBottom: '20px' }}>
+                  <span style={{ marginRight: '20px' }}>{size}</span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button darkMode onClick={() => {}} size={size}>
+                      Normal
+                    </Button>
+                  </span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button darkMode onClick={() => {}} size={size}>
+                      <Button.Addon>
+                        <span role="img" aria-label="Rocket">
+                          🚀
+                        </span>
+                      </Button.Addon>
+                      With addon
+                    </Button>
+                  </span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button active darkMode onClick={() => {}} size={size}>
+                      Hover
+                    </Button>
+                  </span>
+                  <span style={{ marginRight: '20px' }}>
+                    <Button darkMode disabled onClick={() => {}} size={size}>
+                      Disabled
+                    </Button>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      );
+    },
     {
       info: {
         inline: false,

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -38,6 +38,7 @@
   border-color: var(--rvr-border-color-primary);
 }
 
+.primary.active,
 .primary:active,
 .primary:hover,
 .primary:focus {
@@ -61,6 +62,7 @@
   border-color: var(--rvr-border-color-teal);
 }
 
+.teal.active,
 .teal:active,
 .teal:hover,
 .teal:focus {
@@ -84,6 +86,7 @@
   border-color: var(--rvr-border-color-secondary);
 }
 
+.secondary.active,
 .secondary:active,
 .secondary:hover,
 .secondary:focus {
@@ -107,6 +110,7 @@
   border-color: var(--rvr-border-color-success);
 }
 
+.success.active,
 .success:active,
 .success:hover,
 .success:focus {
@@ -130,6 +134,7 @@
   border-color: var(--rvr-border-color-tertiary);
 }
 
+.tertiary.active,
 .tertiary:active,
 .tertiary:hover,
 .tertiary:focus {
@@ -145,6 +150,54 @@
   border-color: var(--rvr-border-color-tertiary-disabled);
 }
 
+.link,
+.link:link,
+.link:visited {
+  color: var(--rvr-color-link);
+  background-color: var(--rvr-bg-color-link);
+  border-color: var(--rvr-border-color-link);
+}
+
+.link.active,
+.link:active,
+.link:hover,
+.link:focus {
+  color: var(--rvr-color-link-active);
+  background-color: var(--rvr-bg-color-link-active);
+  border-color: var(--rvr-border-color-link-active);
+}
+
+.link:disabled,
+.link[disabled] {
+  color: var(--rvr-color-link-disabled);
+  background-color: var(--rvr-bg-color-link-disabled);
+  border-color: var(--rvr-border-color-link-disabled);
+}
+
+.text,
+.text:link,
+.text:visited {
+  color: var(--rvr-color-text);
+  background-color: var(--rvr-bg-color-text);
+  border-color: var(--rvr-border-color-text);
+}
+
+.text.active,
+.text:active,
+.text:hover,
+.text:focus {
+  color: var(--rvr-color-text-active);
+  background-color: var(--rvr-bg-color-text-active);
+  border-color: var(--rvr-border-color-text-active);
+}
+
+.text:disabled,
+.text[disabled] {
+  color: var(--rvr-color-text-disabled);
+  background-color: var(--rvr-bg-color-text-disabled);
+  border-color: var(--rvr-border-color-text-disabled);
+}
+
 /* Dark mode */
 
 .darkMode,
@@ -155,6 +208,7 @@
   border-color: var(--rvr-border-color-darkMode);
 }
 
+.darkMode.active,
 .darkMode:active,
 .darkMode:hover,
 .darkMode:focus {

--- a/src/components/Button/style.css
+++ b/src/components/Button/style.css
@@ -2,6 +2,8 @@
   -webkit-appearance: none;
   background: transparent none;
   border: var(--rvr-border-width-md) solid transparent;
+  box-sizing: border-box;
+  cursor: pointer;
   font-size: var(--rvr-font-size-md);
   line-height: var(--rvr-line-height-sm);
   transition: 0.2s linear background-color, 0.2s linear border-color, 0.2s linear color;
@@ -9,6 +11,12 @@
   flex-flow: row nowrap;
   align-content: center;
   text-decoration: none;
+}
+
+.Button.disabled,
+.Button:disabled,
+.Button[disabled] {
+  cursor: default;
 }
 
 /* Sizes */
@@ -28,198 +36,276 @@
   border-radius: calc(var(--rvr-space-bordered-lg) + (var(--rvr-line-height-md) / 2));
 }
 
+/* Circle */
+.circle {
+  display: inline-block;
+  text-align: center;
+}
+
+.sm.circle {
+  height: calc(var(--rvr-space-bordered-xs) * 2 + var(--rvr-line-height-md));
+  width: calc(var(--rvr-space-bordered-xs) * 2 + var(--rvr-line-height-md));
+  padding: var(--rvr-space-bordered-xs);
+  border-radius: calc(var(--rvr-space-bordered-sm) + (var(--rvr-line-height-md) / 2));
+}
+
+.md.circle {
+  height: calc(var(--rvr-space-bordered-sm) * 2 + var(--rvr-line-height-md));
+  width: calc(var(--rvr-space-bordered-sm) * 2 + var(--rvr-line-height-md));
+  padding: var(--rvr-space-bordered-sm);
+  border-radius: calc(var(--rvr-space-bordered-md) + (var(--rvr-line-height-md) / 2));
+}
+
+.lg.circle {
+  height: calc(var(--rvr-space-bordered-md) * 2 + var(--rvr-line-height-md));
+  width: calc(var(--rvr-space-bordered-md) * 2 + var(--rvr-line-height-md));
+  padding: var(--rvr-space-bordered-md);
+  border-radius: calc(var(--rvr-space-bordered-md) + (var(--rvr-line-height-md) / 2));
+}
+
 /* Button level colors */
 
 .primary,
 .primary:link,
 .primary:visited {
-  color: var(--rvr-color-primary);
-  background-color: var(--rvr-bg-color-primary);
-  border-color: var(--rvr-border-color-primary);
+  color: var(--rvr-btn-color-primary);
+  background-color: var(--rvr-btn-bg-color-primary);
+  border-color: var(--rvr-btn-border-color-primary);
 }
 
 .primary.active,
 .primary:active,
+.primary.hover,
 .primary:hover,
+.primary.focus,
 .primary:focus {
-  color: var(--rvr-color-primary-active);
-  background-color: var(--rvr-bg-color-primary-active);
-  border-color: var(--rvr-border-color-primary-active);
+  color: var(--rvr-btn-color-primary-active);
+  background-color: var(--rvr-btn-bg-color-primary-active);
+  border-color: var(--rvr-btn-border-color-primary-active);
 }
 
+.primary.disabled,
 .primary:disabled,
 .primary[disabled] {
-  color: var(--rvr-color-primary-disabled);
-  background-color: var(--rvr-bg-color-primary-disabled);
-  border-color: var(--rvr-border-color-primary-disabled);
+  color: var(--rvr-btn-color-primary-disabled);
+  background-color: var(--rvr-btn-bg-color-primary-disabled);
+  border-color: var(--rvr-btn-border-color-primary-disabled);
 }
 
-.teal,
-.teal:link,
-.teal:visited {
-  color: var(--rvr-color-teal);
-  background-color: var(--rvr-bg-color-teal);
-  border-color: var(--rvr-border-color-teal);
+.primary-alt,
+.primary-alt:link,
+.primary-alt:visited {
+  color: var(--rvr-btn-color-primary-alt);
+  background-color: var(--rvr-btn-bg-color-primary-alt);
+  border-color: var(--rvr-btn-border-color-primary-alt);
 }
 
-.teal.active,
-.teal:active,
-.teal:hover,
-.teal:focus {
-  color: var(--rvr-color-teal-active);
-  background-color: var(--rvr-bg-color-teal-active);
-  border-color: var(--rvr-border-color-teal-active);
+.primary-alt.active,
+.primary-alt:active,
+.primary-alt.hover,
+.primary-alt:hover,
+.primary-alt.focus,
+.primary-alt:focus {
+  color: var(--rvr-btn-color-primary-alt-active);
+  background-color: var(--rvr-btn-bg-color-primary-alt-active);
+  border-color: var(--rvr-btn-border-color-primary-alt-active);
 }
 
-.teal:disabled,
-.teal[disabled] {
-  color: var(--rvr-color-teal-disabled);
-  background-color: var(--rvr-bg-color-teal-disabled);
-  border-color: var(--rvr-border-color-teal-disabled);
+.primary-alt.disabled,
+.primary-alt:disabled,
+.primary-alt[disabled] {
+  color: var(--rvr-btn-color-primary-alt-disabled);
+  background-color: var(--rvr-btn-bg-color-primary-alt-disabled);
+  border-color: var(--rvr-btn-border-color-primary-alt-disabled);
 }
 
 .secondary,
 .secondary:link,
 .secondary:visited {
-  color: var(--rvr-color-secondary);
-  background-color: var(--rvr-bg-color-secondary);
-  border-color: var(--rvr-border-color-secondary);
+  color: var(--rvr-btn-color-secondary);
+  background-color: var(--rvr-btn-bg-color-secondary);
+  border-color: var(--rvr-btn-border-color-secondary);
 }
 
 .secondary.active,
 .secondary:active,
+.secondary.hover,
 .secondary:hover,
+.secondary.focus,
 .secondary:focus {
-  color: var(--rvr-color-secondary-active);
-  background-color: var(--rvr-bg-color-secondary-active);
-  border-color: var(--rvr-border-color-secondary-active);
+  color: var(--rvr-btn-color-secondary-active);
+  background-color: var(--rvr-btn-bg-color-secondary-active);
+  border-color: var(--rvr-btn-border-color-secondary-active);
 }
 
+.secondary.disabled,
 .secondary:disabled,
 .secondary[disabled] {
-  color: var(--rvr-color-secondary-disabled);
-  background-color: var(--rvr-bg-color-secondary-disabled);
-  border-color: var(--rvr-border-color-secondary-disabled);
-}
-
-.success,
-.success:link,
-.success:visited {
-  color: var(--rvr-color-success);
-  background-color: var(--rvr-bg-color-success);
-  border-color: var(--rvr-border-color-success);
-}
-
-.success.active,
-.success:active,
-.success:hover,
-.success:focus {
-  color: var(--rvr-color-success-active);
-  background-color: var(--rvr-bg-color-success-active);
-  border-color: var(--rvr-border-color-success-active);
-}
-
-.success:disabled,
-.success[disabled] {
-  color: var(--rvr-color-success-disabled);
-  background-color: var(--rvr-bg-color-success-disabled);
-  border-color: var(--rvr-border-color-success-disabled);
+  color: var(--rvr-btn-color-secondary-disabled);
+  background-color: var(--rvr-btn-bg-color-secondary-disabled);
+  border-color: var(--rvr-btn-border-color-secondary-disabled);
 }
 
 .tertiary,
 .tertiary:link,
 .tertiary:visited {
-  color: var(--rvr-color-tertiary);
-  background-color: var(--rvr-bg-color-tertiary);
-  border-color: var(--rvr-border-color-tertiary);
+  color: var(--rvr-btn-color-tertiary);
+  background-color: var(--rvr-btn-bg-color-tertiary);
+  border-color: var(--rvr-btn-border-color-tertiary);
 }
 
 .tertiary.active,
 .tertiary:active,
+.tertiary.hover,
 .tertiary:hover,
+.tertiary.focus,
 .tertiary:focus {
-  color: var(--rvr-color-tertiary-active);
-  background-color: var(--rvr-bg-color-tertiary-active);
-  border-color: var(--rvr-border-color-tertiary-active);
+  color: var(--rvr-btn-color-tertiary-active);
+  background-color: var(--rvr-btn-bg-color-tertiary-active);
+  border-color: var(--rvr-btn-border-color-tertiary-active);
 }
 
+.tertiary.disabled,
 .tertiary:disabled,
 .tertiary[disabled] {
-  color: var(--rvr-color-tertiary-disabled);
-  background-color: var(--rvr-bg-color-tertiary-disabled);
-  border-color: var(--rvr-border-color-tertiary-disabled);
+  color: var(--rvr-btn-color-tertiary-disabled);
+  background-color: var(--rvr-btn-bg-color-tertiary-disabled);
+  border-color: var(--rvr-btn-border-color-tertiary-disabled);
+}
+
+.success,
+.success:link,
+.success:visited {
+  color: var(--rvr-btn-color-success);
+  background-color: var(--rvr-btn-bg-color-success);
+  border-color: var(--rvr-btn-border-color-success);
+}
+
+.success.active,
+.success:active,
+.success.hover,
+.success:hover,
+.success.focus,
+.success:focus {
+  color: var(--rvr-btn-color-success-active);
+  background-color: var(--rvr-btn-bg-color-success-active);
+  border-color: var(--rvr-btn-border-color-success-active);
+}
+
+.success.disabled,
+.success:disabled,
+.success[disabled] {
+  color: var(--rvr-btn-color-primary-alt-disabled);
+  background-color: var(--rvr-btn-bg-color-primary-alt-disabled);
+  border-color: var(--rvr-btn-border-color-primary-alt-disabled);
+}
+
+.danger,
+.danger:link,
+.danger:visited {
+  color: var(--rvr-btn-color-danger);
+  background-color: var(--rvr-btn-bg-color-danger);
+  border-color: var(--rvr-btn-border-color-danger);
+}
+
+.danger.active,
+.danger:active,
+.danger.hover,
+.danger:hover,
+.danger.focus,
+.danger:focus {
+  color: var(--rvr-btn-color-danger-active);
+  background-color: var(--rvr-btn-bg-color-danger-active);
+  border-color: var(--rvr-btn-border-color-danger-active);
+}
+
+.danger.disabled,
+.danger:disabled,
+.danger[disabled] {
+  color: var(--rvr-btn-color-primary-alt-disabled);
+  background-color: var(--rvr-btn-bg-color-primary-alt-disabled);
+  border-color: var(--rvr-btn-border-color-primary-alt-disabled);
 }
 
 .link,
 .link:link,
 .link:visited {
-  color: var(--rvr-color-link);
-  background-color: var(--rvr-bg-color-link);
-  border-color: var(--rvr-border-color-link);
+  color: var(--rvr-btn-color-link);
+  background-color: var(--rvr-btn-bg-color-link);
+  border-color: var(--rvr-btn-border-color-link);
 }
 
 .link.active,
 .link:active,
+.link.hover,
 .link:hover,
+.link.focus,
 .link:focus {
-  color: var(--rvr-color-link-active);
-  background-color: var(--rvr-bg-color-link-active);
-  border-color: var(--rvr-border-color-link-active);
+  color: var(--rvr-btn-color-link-active);
+  background-color: var(--rvr-btn-bg-color-link-active);
+  border-color: var(--rvr-btn-border-color-link-active);
 }
 
+.link.disabled,
 .link:disabled,
 .link[disabled] {
-  color: var(--rvr-color-link-disabled);
-  background-color: var(--rvr-bg-color-link-disabled);
-  border-color: var(--rvr-border-color-link-disabled);
+  color: var(--rvr-btn-color-link-disabled);
+  background-color: var(--rvr-btn-bg-color-link-disabled);
+  border-color: var(--rvr-btn-border-color-link-disabled);
 }
 
 .text,
 .text:link,
 .text:visited {
-  color: var(--rvr-color-text);
-  background-color: var(--rvr-bg-color-text);
-  border-color: var(--rvr-border-color-text);
+  color: var(--rvr-btn-color-text);
+  background-color: var(--rvr-btn-bg-color-text);
+  border-color: var(--rvr-btn-border-color-text);
 }
 
 .text.active,
 .text:active,
+.text.hover,
 .text:hover,
+.text.focus,
 .text:focus {
-  color: var(--rvr-color-text-active);
-  background-color: var(--rvr-bg-color-text-active);
-  border-color: var(--rvr-border-color-text-active);
+  color: var(--rvr-btn-color-text-active);
+  background-color: var(--rvr-btn-bg-color-text-active);
+  border-color: var(--rvr-btn-border-color-text-active);
 }
 
+.text.disabled,
 .text:disabled,
 .text[disabled] {
-  color: var(--rvr-color-text-disabled);
-  background-color: var(--rvr-bg-color-text-disabled);
-  border-color: var(--rvr-border-color-text-disabled);
+  color: var(--rvr-btn-color-text-disabled);
+  background-color: var(--rvr-btn-bg-color-text-disabled);
+  border-color: var(--rvr-btn-border-color-text-disabled);
 }
 
-/* Dark mode */
+/* Hollow */
 
-.darkMode,
-.darkMode:link,
-.darkMode:visited {
-  color: var(--rvr-color-darkMode);
-  background-color: var(--rvr-bg-color-darkMode);
-  border-color: var(--rvr-border-color-darkMode);
+.hollow,
+.hollow:link,
+.hollow:visited {
+  color: var(--rvr-btn-color-hollow);
+  background-color: var(--rvr-btn-bg-color-hollow);
+  border-color: var(--rvr-btn-border-color-hollow);
 }
 
-.darkMode.active,
-.darkMode:active,
-.darkMode:hover,
-.darkMode:focus {
-  color: var(--rvr-color-darkMode-active);
-  background-color: var(--rvr-bg-color-darkMode-active);
-  border-color: var(--rvr-border-color-darkMode-active);
+.hollow.active,
+.hollow:active,
+.hollow.hover,
+.hollow:hover,
+.hollow.focus,
+.hollow:focus {
+  color: var(--rvr-btn-color-hollow-active);
+  background-color: var(--rvr-btn-bg-color-hollow-active);
+  border-color: var(--rvr-btn-border-color-hollow-active);
 }
 
-.darkMode:disabled,
-.darkMode[disabled] {
-  color: var(--rvr-color-darkMode-disabled);
-  background-color: var(--rvr-bg-color-darkMode-disabled);
-  border-color: var(--rvr-border-color-darkMode-disabled);
+.hollow.disabled,
+.hollow:disabled,
+.hollow[disabled] {
+  color: var(--rvr-btn-color-hollow-disabled);
+  background-color: var(--rvr-btn-bg-color-hollow-disabled);
+  border-color: var(--rvr-btn-border-color-hollow-disabled);
 }

--- a/src/components/Button/test.js
+++ b/src/components/Button/test.js
@@ -34,11 +34,11 @@ describe('Button', () => {
     });
   });
 
-  describe('props.darkMode', () => {
+  describe('props.hollow', () => {
     // Our current test build doesn't do css modules, so this won't work
-    // it('adds darkMode className', () => {
-    //   const wrapper = shallow(<Button darkMode />);
-    //   expect(wrapper.hasClass(style.darkMode)).toEqual(true);
+    // it('adds hollow className', () => {
+    //   const wrapper = shallow(<Button hollow />);
+    //   expect(wrapper.hasClass(style.hollow)).toEqual(true);
     // });
   });
 

--- a/src/components/Responsive/Grid/index.js
+++ b/src/components/Responsive/Grid/index.js
@@ -33,7 +33,7 @@ const Grid = ({ breakpoints, children, columns, gutter, ...passedProps }) => {
             a child, use the breakpoint's colSpan for that child
           */
           responsiveChildren = React.Children.map(children, child => {
-            const childProps = child.props || {};
+            const childProps = (child && child.props) || {};
             const { clear = false, colSpan = 1, offset = 0 } = childProps;
             let { breakpoints: childBreakpoints } = childProps;
             childBreakpoints = childBreakpoints || {};

--- a/src/shared/buttons.css
+++ b/src/shared/buttons.css
@@ -1,121 +1,136 @@
 :root {
   /* PRIMARY */
-  --rvr-color-primary: var(--rvr-white);
-  --rvr-bg-color-primary: var(--rvr-light-blue);
-  --rvr-border-color-primary: var(--rvr-bg-color-primary);
+  --rvr-btn-color-primary: var(--rvr-white);
+  --rvr-btn-bg-color-primary: var(--rvr-light-blue);
+  --rvr-btn-border-color-primary: var(--rvr-btn-bg-color-primary);
 
   /* Active */
-  --rvr-color-primary-active: var(--rvr-color-primary);
-  --rvr-bg-color-primary-active: var(--rvr-light-blue-hover);
-  --rvr-border-color-primary-active: var(--rvr-bg-color-primary-active);
+  --rvr-btn-color-primary-active: var(--rvr-btn-color-primary);
+  --rvr-btn-bg-color-primary-active: var(--rvr-light-blue-hover);
+  --rvr-btn-border-color-primary-active: var(--rvr-btn-bg-color-primary-active);
 
   /* Disabled */
-  --rvr-color-primary-disabled: var(--rvr-white);
-  --rvr-bg-color-primary-disabled: var(--rvr-gray-lite-3);
-  --rvr-border-color-primary-disabled: var(--rvr-gray-lite-3);
+  --rvr-btn-color-primary-disabled: var(--rvr-white);
+  --rvr-btn-bg-color-primary-disabled: var(--rvr-gray-lite-3);
+  --rvr-btn-border-color-primary-disabled: var(--rvr-gray-lite-3);
 
-  /* TEAL */
-  --rvr-color-teal: var(--rvr-white);
-  --rvr-bg-color-teal: var(--rvr-teal);
-  --rvr-border-color-teal: var(--rvr-bg-color-teal);
+  /* PRIMARY-ALT (TEAL) */
+  --rvr-btn-color-primary-alt: var(--rvr-white);
+  --rvr-btn-bg-color-primary-alt: var(--rvr-teal);
+  --rvr-btn-border-color-primary-alt: var(--rvr-btn-bg-color-primary-alt);
 
   /* Active */
-  --rvr-color-teal-active: var(--rvr-color-teal);
-  --rvr-bg-color-teal-active: var(--rvr-teal-lite-1);
-  --rvr-border-color-teal-active: var(--rvr-bg-color-teal-active);
+  --rvr-btn-color-primary-alt-active: var(--rvr-btn-color-primary-alt);
+  --rvr-btn-bg-color-primary-alt-active: var(--rvr-teal-lite-1);
+  --rvr-btn-border-color-primary-alt-active: var(--rvr-btn-bg-color-primary-alt-active);
 
   /* Disabled */
-  --rvr-color-teal-disabled: var(--rvr-color-primary-disabled);
-  --rvr-bg-color-teal-disabled: var(--rvr-bg-color-primary-disabled);
-  --rvr-border-color-teal-disabled: var(--rvr-border-color-primary-disabled);
+  --rvr-btn-color-primary-alt-disabled: var(--rvr-btn-color-primary-disabled);
+  --rvr-btn-bg-color-primary-alt-disabled: var(--rvr-btn-bg-color-primary-disabled);
+  --rvr-btn-border-color-primary-alt-disabled: var(--rvr-btn-border-color-primary-disabled);
 
   /* SECONDARY */
-  --rvr-color-secondary: var(--rvr-light-blue);
-  --rvr-bg-color-secondary: var(--rvr-white);
-  --rvr-border-color-secondary: var(--rvr-color-secondary);
+  --rvr-btn-color-secondary: var(--rvr-light-blue);
+  --rvr-btn-bg-color-secondary: var(--rvr-white);
+  --rvr-btn-border-color-secondary: var(--rvr-btn-color-secondary);
 
   /* Active */
-  --rvr-color-secondary-active: var(--rvr-color-primary-active);
-  --rvr-bg-color-secondary-active: var(--rvr-bg-color-primary-active);
-  --rvr-border-color-secondary-active: var(--rvr-border-color-primary-active);
+  --rvr-btn-color-secondary-active: var(--rvr-btn-color-primary-active);
+  --rvr-btn-bg-color-secondary-active: var(--rvr-btn-bg-color-primary-active);
+  --rvr-btn-border-color-secondary-active: var(--rvr-btn-border-color-primary-active);
 
   /* Disabled */
-  --rvr-color-secondary-disabled: var(--rvr-gray-lite-3);
-  --rvr-bg-color-secondary-disabled: var(--rvr-gray-lite-6);
-  --rvr-border-color-secondary-disabled: var(--rvr-gray-lite-4);
-
-  /* SUCCESS */
-  --rvr-color-success: var(--rvr-white);
-  --rvr-bg-color-success: var(--rvr-green);
-  --rvr-border-color-success: var(--rvr-bg-color-success);
-
-  /* Active */
-  --rvr-color-success-active: var(--rvr-white);
-  --rvr-bg-color-success-active: var(--rvr-green-lite-1);
-  --rvr-border-color-success-active: var(--rvr-bg-color-success-active);
-
-  /* Disabled */
-  --rvr-color-success-disabled: var(--rvr-color-secondary-disabled);
-  --rvr-bg-color-success-disabled: var(--rvr-bg-color-secondary-disabled);
-  --rvr-border-color-success-disabled: var(--rvr-border-color-secondary-disabled);
+  --rvr-btn-color-secondary-disabled: var(--rvr-gray-lite-3);
+  --rvr-btn-bg-color-secondary-disabled: var(--rvr-gray-lite-6);
+  --rvr-btn-border-color-secondary-disabled: var(--rvr-gray-lite-4);
 
   /* TERTIARY */
-  --rvr-color-tertiary: var(--rvr-gray-lite-2);
-  --rvr-bg-color-tertiary: var(--rvr-white);
-  --rvr-border-color-tertiary: var(--rvr-gray-lite-3);
+  --rvr-btn-color-tertiary: var(--rvr-gray-lite-2);
+  --rvr-btn-bg-color-tertiary: var(--rvr-white);
+  --rvr-btn-border-color-tertiary: var(--rvr-gray-lite-3);
 
   /* Active */
-  --rvr-color-tertiary-active: var(--rvr-gray);
-  --rvr-bg-color-tertiary-active: var(--rvr-gray-lite-6);
-  --rvr-border-color-tertiary-active: var(--rvr-gray-lite-2);
+  --rvr-btn-color-tertiary-active: var(--rvr-gray);
+  --rvr-btn-bg-color-tertiary-active: var(--rvr-gray-lite-6);
+  --rvr-btn-border-color-tertiary-active: var(--rvr-gray-lite-2);
 
   /* Disabled */
-  --rvr-color-tertiary-disabled: var(--rvr-color-secondary-disabled);
-  --rvr-bg-color-tertiary-disabled: var(--rvr-bg-color-secondary-disabled);
-  --rvr-border-color-tertiary-disabled: var(--rvr-border-color-secondary-disabled);
+  --rvr-btn-color-tertiary-disabled: var(--rvr-btn-color-secondary-disabled);
+  --rvr-btn-bg-color-tertiary-disabled: var(--rvr-btn-bg-color-secondary-disabled);
+  --rvr-btn-border-color-tertiary-disabled: var(--rvr-btn-border-color-secondary-disabled);
+
+  /* SUCCESS */
+  --rvr-btn-color-success: var(--rvr-white);
+  --rvr-btn-bg-color-success: var(--rvr-green);
+  --rvr-btn-border-color-success: var(--rvr-btn-bg-color-success);
+
+  /* Active */
+  --rvr-btn-color-success-active: var(--rvr-white);
+  --rvr-btn-bg-color-success-active: var(--rvr-green-lite-1);
+  --rvr-btn-border-color-success-active: var(--rvr-btn-bg-color-success-active);
+
+  /* Disabled */
+  --rvr-btn-color-success-disabled: var(--rvr-btn-color-secondary-disabled);
+  --rvr-btn-bg-color-success-disabled: var(--rvr-btn-bg-color-secondary-disabled);
+  --rvr-btn-border-color-success-disabled: var(--rvr-btn-border-color-secondary-disabled);
+
+  /* DANGER */
+  --rvr-btn-color-danger: var(--rvr-white);
+  --rvr-btn-bg-color-danger: var(--rvr-red);
+  --rvr-btn-border-color-danger: var(--rvr-btn-bg-color-danger);
+
+  /* Active */
+  --rvr-btn-color-danger-active: var(--rvr-white);
+  --rvr-btn-bg-color-danger-active: var(--rvr-red-lite-1);
+  --rvr-btn-border-color-danger-active: var(--rvr-btn-bg-color-danger-active);
+
+  /* Disabled */
+  --rvr-btn-color-danger-disabled: var(--rvr-btn-color-secondary-disabled);
+  --rvr-btn-bg-color-danger-disabled: var(--rvr-btn-bg-color-secondary-disabled);
+  --rvr-btn-border-color-danger-disabled: var(--rvr-btn-border-color-secondary-disabled);
 
   /* LINK */
-  --rvr-color-link: var(--rvr-light-blue);
-  --rvr-bg-color-link: transparent;
-  --rvr-border-color-link: var(--rvr-bg-color-link);
+  --rvr-btn-color-link: var(--rvr-light-blue);
+  --rvr-btn-bg-color-link: transparent;
+  --rvr-btn-border-color-link: var(--rvr-btn-bg-color-link);
 
   /* Active */
-  --rvr-color-link-active: var(--rvr-light-blue-hover);
-  --rvr-bg-color-link-active: var(--rvr-bg-color-link);
-  --rvr-border-color-link-active: var(--rvr-bg-color-link-active);
+  --rvr-btn-color-link-active: var(--rvr-light-blue-hover);
+  --rvr-btn-bg-color-link-active: var(--rvr-btn-bg-color-link);
+  --rvr-btn-border-color-link-active: var(--rvr-btn-bg-color-link-active);
 
   /* Disabled */
-  --rvr-color-link-disabled: var(--rvr-gray-40);
-  --rvr-bg-color-link-disabled: var(--rvr-bg-color-link);
-  --rvr-border-color-link-disabled: var(--rvr-bg-color-link-disabled);
+  --rvr-btn-color-link-disabled: var(--rvr-gray-40);
+  --rvr-btn-bg-color-link-disabled: var(--rvr-btn-bg-color-link);
+  --rvr-btn-border-color-link-disabled: var(--rvr-btn-bg-color-link-disabled);
 
   /* TEXT */
-  --rvr-color-text: var(--rvr-gray-80);
-  --rvr-bg-color-text: transparent;
-  --rvr-border-color-text: var(--rvr-bg-color-text);
+  --rvr-btn-color-text: var(--rvr-gray-80);
+  --rvr-btn-bg-color-text: transparent;
+  --rvr-btn-border-color-text: var(--rvr-btn-bg-color-text);
 
   /* Active */
-  --rvr-color-text-active: var(--rvr-gray-90);
-  --rvr-bg-color-text-active: var(--rvr-bg-color-text);
-  --rvr-border-color-text-active: var(--rvr-bg-color-text-active);
+  --rvr-btn-color-text-active: var(--rvr-gray-90);
+  --rvr-btn-bg-color-text-active: var(--rvr-btn-bg-color-text);
+  --rvr-btn-border-color-text-active: var(--rvr-btn-bg-color-text-active);
 
   /* Disabled */
-  --rvr-color-text-disabled: var(--rvr-gray-40);
-  --rvr-bg-color-text-disabled: var(--rvr-bg-color-text);
-  --rvr-border-color-text-disabled: var(--rvr-bg-color-text-disabled);
+  --rvr-btn-color-text-disabled: var(--rvr-gray-40);
+  --rvr-btn-bg-color-text-disabled: var(--rvr-btn-bg-color-text);
+  --rvr-btn-border-color-text-disabled: var(--rvr-btn-bg-color-text-disabled);
 
   /* DARK MODE */
-  --rvr-color-darkMode: var(--rvr-white);
-  --rvr-bg-color-darkMode: transparent;
-  --rvr-border-color-darkMode: var(--rvr-white);
+  --rvr-btn-color-hollow: var(--rvr-white);
+  --rvr-btn-bg-color-hollow: transparent;
+  --rvr-btn-border-color-hollow: var(--rvr-btn-color-hollow);
 
   /* Active */
-  --rvr-color-darkMode-active: var(--rvr-gray-lite-3);
-  --rvr-bg-color-darkMode-active: var(--rvr-bg-color-darkMode);
-  --rvr-border-color-darkMode-active: var(--rvr-gray-lite-3);
+  --rvr-btn-color-hollow-active: var(--rvr-gray-lite-3);
+  --rvr-btn-bg-color-hollow-active: var(--rvr-bg-color-hollow);
+  --rvr-btn-border-color-hollow-active: var(--rvr-btn-color-hollow-active);
 
   /* Disabled */
-  --rvr-color-darkMode-disabled: #fff6;
-  --rvr-bg-color-darkMode-disabled: var(--rvr-bg-color-darkMode);
-  --rvr-border-color-darkMode-disabled: #fff6;
+  --rvr-btn-color-hollow-disabled: #fff6;
+  --rvr-btn-bg-color-hollow-disabled: var(--rvr-bg-color-hollow);
+  --rvr-btn-border-color-hollow-disabled: #fff6;
 }

--- a/src/shared/buttons.css
+++ b/src/shared/buttons.css
@@ -74,6 +74,36 @@
   --rvr-bg-color-tertiary-disabled: var(--rvr-bg-color-secondary-disabled);
   --rvr-border-color-tertiary-disabled: var(--rvr-border-color-secondary-disabled);
 
+  /* LINK */
+  --rvr-color-link: var(--rvr-light-blue);
+  --rvr-bg-color-link: transparent;
+  --rvr-border-color-link: var(--rvr-bg-color-link);
+
+  /* Active */
+  --rvr-color-link-active: var(--rvr-light-blue-hover);
+  --rvr-bg-color-link-active: var(--rvr-bg-color-link);
+  --rvr-border-color-link-active: var(--rvr-bg-color-link-active);
+
+  /* Disabled */
+  --rvr-color-link-disabled: var(--rvr-gray-40);
+  --rvr-bg-color-link-disabled: var(--rvr-bg-color-link);
+  --rvr-border-color-link-disabled: var(--rvr-bg-color-link-disabled);
+
+  /* TEXT */
+  --rvr-color-text: var(--rvr-gray-80);
+  --rvr-bg-color-text: transparent;
+  --rvr-border-color-text: var(--rvr-bg-color-text);
+
+  /* Active */
+  --rvr-color-text-active: var(--rvr-gray-90);
+  --rvr-bg-color-text-active: var(--rvr-bg-color-text);
+  --rvr-border-color-text-active: var(--rvr-bg-color-text-active);
+
+  /* Disabled */
+  --rvr-color-text-disabled: var(--rvr-gray-40);
+  --rvr-bg-color-text-disabled: var(--rvr-bg-color-text);
+  --rvr-border-color-text-disabled: var(--rvr-bg-color-text-disabled);
+
   /* DARK MODE */
   --rvr-color-darkMode: var(--rvr-white);
   --rvr-bg-color-darkMode: transparent;

--- a/src/shared/colors.css
+++ b/src/shared/colors.css
@@ -10,6 +10,9 @@
   --rvr-green: #63bf52;
   --rvr-green-lite-1: #69cc58;
   --rvr-green-lite-2: #e9fcf6;
+  --rvr-red: #de4543;
+  --rvr-red-lite-1: #fa6866;
+  --rvr-red-lite-2: #fa6866; /* Unused */
   --rvr-teal: #44c0c2;
   --rvr-teal-lite-1: #47cacc;
   --rvr-salmon: #f76764;
@@ -38,8 +41,8 @@
   --rvr-bg-color-neutral: var(--rvr-gray-lite-6);
 
   /* Danger */
-  --rvr-color-danger: var(--rvr-salmon);
-  --rvr-bg-color-danger: var(--rvr-salmon-lite-2);
+  --rvr-color-danger: var(--rvr-red);
+  --rvr-bg-color-danger: var(--rvr-red-lite-2);
 
   /* Warning */
   --rvr-color-warning: var(--rvr-yellow);

--- a/src/shared/colors.css
+++ b/src/shared/colors.css
@@ -111,7 +111,10 @@
   --charting-magenta-light: #ffa4de;
   --teal-hover: #00a19b;
   --info-light: #e3f6fc;
-  --gray-40: #cccfd2;
+  */
+  --rvr-gray-40: #cccfd2;
+
+  /*
   --charting-purple-light: #b5ade1;
   --medium-blue-hover: #007499;
   --aqua-marine-two: #47cacc; */


### PR DESCRIPTION
Added .yalc instructions with a big warning to the README.

Added a "Text" level to button that looks like blue text, no border. I did this because:
1. I noticed Invision had a button like that in the stylesheet.
2. Bootstrap and Foundation both have buttons like that, but theirs are called "Link"s, both preserve the padding of normal buttons, and one has an underline on hover.
3. In Zeplin, Egle had two borderless buttons, one called "Text/Blue" and one called "Text/Gray", and without padding.

I figured "text" was a little less confusing than "link" as a modifier, since these don't get typical underline styles.
I also figured I'd leave the padding / sizing as it is, following Bootstrap/Foundation, and ppl can override the styles with `padding: 0` when/if necessary.
I don't know what to do as far as naming convention to add the gray and blue variations. (Request for comments)