### PR TITLE
added 2nd Chevron Icon for backwards compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cision/rover-ui",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "publishConfig": {
     "tag": "v1.2.1"
   },

--- a/src/components/Icon/index.js
+++ b/src/components/Icon/index.js
@@ -216,6 +216,7 @@ export const iconsMap = {
   chat: Chat,
   check: Check,
   'chevron-down': Chevron,
+  chevron: Chevron, //for backwards compatibility
   'chevron-left': ChevronLeft,
   'chevron-right': ChevronRight,
   'chevron-up': ChevronUp,


### PR DESCRIPTION
I'll be spot checking to make sure there aren't anymore renamed icons, but I feel like this is the last highly used icon to have this issue.