### PR TITLE
fix: validate image asynchronously by HTMLImageElement instead of XHR

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "publishConfig": {
-    "tag": "v1.2.1"
+    "tag": "v1.2.3"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -15,6 +15,8 @@ const semanticSizes = {
 // This function will be used in a useEffect so make sure it returns a cleanup function
 function defaultImageFetcher({ onLoad, onError, src }) {
   const img = new Image();
+  img.referrerPolicy = 'no-referrer';
+  img.crossOrigin = 'Anonymous';
   img.onload = function() {
     if ('naturalHeight' in this) {
       if (this.naturalHeight + this.naturalWidth === 0) {

--- a/src/components/Avatar/index.js
+++ b/src/components/Avatar/index.js
@@ -37,7 +37,7 @@ const Avatar = ({
     };
   }, [size]);
 
-  const [loadedImageUrl, setLoadedImageUrl] = useState(null);
+  const [loaded, setLoaded] = useState(false);
 
   const initials = useMemo(() => {
     if (!name) return '';
@@ -52,7 +52,7 @@ const Avatar = ({
   useEffect(() => {
     if (!imageUrl) return () => {};
 
-    setLoadedImageUrl(null);
+    setLoaded(false);
 
     const img = new Image();
     img.onload = function() {
@@ -64,10 +64,10 @@ const Avatar = ({
         return;
       }
 
-      setLoadedImageUrl(imageUrl);
+      setLoaded(imageUrl);
     };
     img.onerror = function() {
-      setLoadedImageUrl(null);
+      setLoaded(true);
     };
     img.src = imageUrl;
 
@@ -81,8 +81,7 @@ const Avatar = ({
 
   const mainStyle = {
     ...sizes,
-    backgroundImage:
-      loadedImageUrl && !loading ? `url(${loadedImageUrl})` : undefined,
+    backgroundImage: loaded && !loading ? `url(${imageUrl})` : undefined,
     ...rest.style,
   };
 
@@ -94,7 +93,7 @@ const Avatar = ({
       {...rest}
       style={mainStyle}
     >
-      {!loading && !loadedImageUrl && initials}
+      {!loading && !loaded && initials}
       {children}
     </div>
   );

--- a/src/components/Avatar/test.js
+++ b/src/components/Avatar/test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import Avatar from './';
 
@@ -25,20 +25,26 @@ describe('Avatar', () => {
   });
 
   it('renders initials of the image url results in non-200 response', () => {
+    const imageUrl = 'http://some.url/not-image';
+    Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', {
+      get: () => 0,
+    });
     const wrapper = shallow(
-      <Avatar name="Helter Skelter" imageUrl="https://picsum.photos/wrong" />
+      <Avatar name="Helter Skelter" imageUrl={imageUrl} />
     );
     expect(wrapper.text()).toEqual('HS');
   });
 
   it('renders an image in bg assuming valid url', () => {
-    const wrapper = shallow(
-      <Avatar name="Helter Skelter" imageUrl="http://placekitten.com/60/60" />
-    );
+    const imageUrl = `http://some.url/image.png`;
+    Object.defineProperty(HTMLImageElement.prototype, 'naturalHeight', {
+      get: () => 120,
+    });
+    const wrapper = mount(<Avatar name="Helter Skelter" imageUrl={imageUrl} />);
     expect(wrapper.text()).toEqual('');
-    expect(wrapper.prop('style')).toHaveProperty(
+    expect(wrapper.children().prop('style')).toHaveProperty(
       'backgroundImage',
-      'url(http://placekitten.com/60/60)'
+      `url(${imageUrl})`
     );
   });
 });


### PR DESCRIPTION
Use an HTMLImageElement instance to validate image URLs instead of
checking the response of a HEAD request. The problem with that approach
is that if the servers don't allow HEAD requests, no images will be
loaded even though they are valid URLs. This solution also performs this
validation process asynchronously so no more blocking the main thread by
performing XHR requests.

Fixes #145 