### PR TITLE
Add Callout to exports

### DIFF
--- a/example/src/App.js
+++ b/example/src/App.js
@@ -21,6 +21,7 @@ import {
   Collapse,
   ExpansionPanel,
   Tooltip,
+  Callout,
   // IMPORT_INJECTOR
 } from '@cision/rover-ui';
 
@@ -381,6 +382,13 @@ const App = () => {
             <Button onClick={toggleTooltip}>Button</Button>
           </Tooltip>
         </div>
+      </section>
+      <section>
+        <h1>Callout</h1>
+        <Callout>
+          Oh, man, this is really a callout now, bro. You&apos;re going to want
+          to pay attention to this one, bro.
+        </Callout>
       </section>
       {/** USAGE_INJECTOR */}
     </div>

--- a/package.json
+++ b/package.json
@@ -127,9 +127,9 @@
     "dist"
   ],
   "dependencies": {
-    "classnames": "^2.2.6",
-    "lodash": "^4.17.11",
     "@cision/react-container-query": "1.0.0-alpha.3",
+    "classnames": "^2.2.6",
+    "lodash": "^4.17.15",
     "styled-components": "^4.2.0",
     "styled-system": "^4.1.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@cision/rover-ui",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "publishConfig": {
-    "tag": "v1.4.0"
+    "tag": "v1.4.1"
   },
   "description": "UI Component Library",
   "author": "Matthew Wells (https://github.com/mdespuits)",

--- a/src/components/Callout/index.js
+++ b/src/components/Callout/index.js
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { includes, isFunction } from 'lodash';
+import includes from 'lodash/includes';
+import isFunction from 'lodash/isFunction';
 
 import styles from './style.css';
 

--- a/src/components/Media/story.js
+++ b/src/components/Media/story.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { times } from 'lodash';
+import times from 'lodash/times';
 import { storiesOf } from '@storybook/react';
 import { number, text, select } from '@storybook/addon-knobs';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,26 @@
 // Global CSS variables
+import './shared/buttons.css';
 import './shared/colors.css';
 import './shared/sizing.css';
-import './shared/buttons.css';
 import './shared/variables.css';
 
+export { default as Accordion } from './components/Accordion';
+export { default as Avatar } from './components/Avatar';
 export { default as Badge } from './components/Badge';
 export { default as Bar } from './components/Bar';
 export { default as Button } from './components/Button';
+export { default as Callout } from './components/Callout';
+export { default as Collapse } from './components/Collapse';
+export { default as DeletablePill } from './components/DeletablePill';
+export { default as Dropdown } from './components/Dropdown';
+export { default as EasyDropdown } from './components/EasyDropdown';
+export { default as EasyPill } from './components/EasyPill';
+export { default as ExpansionPanel } from './components/ExpansionPanel';
+export { default as Grid } from './components/Grid';
+export { default as Icon } from './components/Icon';
 export { default as Media } from './components/Media';
 export { default as Paper } from './components/Paper';
-export { default as Grid } from './components/Grid';
+export { default as Pill } from './components/Pill';
 export { default as Responsive } from './components/Responsive';
 export { default as SideTray } from './components/SideTray';
 
@@ -19,14 +30,4 @@ export {
   EasyTabMenu,
 } from './components/TabMenu';
 
-export { default as Icon } from './components/Icon';
-export { default as Pill } from './components/Pill';
-export { default as EasyPill } from './components/EasyPill';
-export { default as DeletablePill } from './components/DeletablePill';
-export { default as Dropdown } from './components/Dropdown';
-export { default as EasyDropdown } from './components/EasyDropdown';
-export { default as Collapse } from './components/Collapse';
-export { default as ExpansionPanel } from './components/ExpansionPanel';
-export { default as Accordion } from './components/Accordion';
-export { default as Avatar } from './components/Avatar';
 export { default as Tooltip, EasyRichTooltip } from './components/Tooltip';


### PR DESCRIPTION
Callout exists, has a story and tests, but wasn't being exported from the package.

Along the way, I found a couple of places importing lodash utilities in a not-tree-shakeable way, so this PR also reduces the library size from around 1.1 MB to 600 KB minified.