### PR TITLE
Simplify Rover CSS module scope name

### DIFF
--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -5041,7 +5041,7 @@ lodash.uniq@^4.5.0:
   resolved "https://trendkite.jfrog.io/trendkite/api/npm/libs-frontend/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
+"lodash@>=3.5 <5", lodash@^4.15.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.15"
   resolved "https://trendkite.jfrog.io/trendkite/api/npm/libs-frontend/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,7 +42,12 @@ export default {
         }),
         postcssCalc(),
       ],
-      modules: true,
+      minimize: true,
+      modules: {
+        getJSON() {},
+        generateScopedName: 'rvr-[sha256:hash:base64:3]',
+        hashPrefix: 'prefix',
+      },
       sourceMap: true,
     }),
     url(),


### PR DESCRIPTION
This simplifies the CSS class name generation considerably. Instead of `.styles__Avatar-{hash}` format, it now is simply `.rvr-{hash}`. Not only does this clarify that this is a Rover class, but it shortens the classname itself and shrinks the build output a bit