### PR TITLE
Reinstates custom 'tag' prop for Button

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,6 +18,7 @@ interface BaseButtonProps {
   hollow?: boolean;
   level?: TButtonLevel;
   size?: TButtonSize;
+  tag?: React.ComponentType<{ [key: string]: unknown }> | null;
 
   // States
   hover?: boolean;
@@ -83,6 +84,7 @@ const Button: ButtonType = ({
   hollow = false,
   level = 'secondary',
   size = 'lg',
+  tag: Tag = null,
   ...passedProps
 }: ButtonElementProps | AnchorElementProps) => {
   const children = initChildren;
@@ -131,6 +133,14 @@ const Button: ButtonType = ({
       ),
     [circle, darkMode, hollow, level, passedClassName, size, truthyStateKeys]
   );
+
+  if (Tag) {
+    return (
+      <Tag {...passedProps} className={className}>
+        {children}
+      </Tag>
+    );
+  }
 
   if (hasHref(passedProps)) {
     return (

--- a/src/components/Button/story.tsx
+++ b/src/components/Button/story.tsx
@@ -13,7 +13,7 @@ import AddonReadme from './Addon/README.md';
 const MyComponent = ({ className = '', ...props }) => (
   <button
     type="button"
-    className={classNames(className, 'MyComponent')}
+    className={classNames(className, 'shadow-xl transform rotate-180')}
     {...props}
   />
 );
@@ -72,6 +72,13 @@ storiesOf('Planets/Button', module)
                 </Button>
               </span>
             ))}
+          </div>
+          <hr />
+          <h2>CustomComponent for Tag</h2>
+          <div style={{ marginBottom: '20px' }}>
+            <Button tag={MyComponent} href="#">
+              MyComponent
+            </Button>
           </div>
           <hr />
           <h2>Tags</h2>


### PR DESCRIPTION
This is useful for consumers using React router and wants to use the custom `<Link>` component instead of a plain old <a> tag.