### PR TITLE
Separate build and development TS config files

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "test": "cross-env CI=1 react-scripts test --env=jsdom",
     "test:watch": "react-scripts test --env=jsdom",
     "test:debug": "react-scripts --inspect-brk test --runInBand --no-cache",
-    "compile": "microbundle-crl --raw --format modern,cjs --no-compress --css-modules 'rvr-[local]__[hash:base64:3]' && mv dist/index.css dist/rover-ui.css",
+    "compile": "microbundle-crl --raw --format modern,cjs --no-compress --tsconfig tsconfig.build.json --css-modules 'rvr-[local]__[hash:base64:3]' && mv dist/index.css dist/rover-ui.css",
     "build": "yarn compile",
     "start": "yarn compile --watch",
     "generate-component": "yarn hygen component new",

--- a/src/components/Callout/story.tsx
+++ b/src/components/Callout/story.tsx
@@ -26,7 +26,7 @@ storiesOf('Star Systems/Callout', module)
 
       const onClose = boolean('Closeable', true);
       const compact = boolean('Compact', false);
-      const onCancel = onClose ? action('closing callout') : null;
+      const onCancel = onClose ? action('closing callout') : () => {};
       const borderless = boolean('Borderless', false);
       const variant = select('Variant', variants, 'info');
 

--- a/src/components/Grid/Entry/Entry.test.tsx
+++ b/src/components/Grid/Entry/Entry.test.tsx
@@ -1,14 +1,10 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount } from 'enzyme';
 
 import { TestComponent } from '../../../setupTests';
 import Entry from './Entry';
 
 describe('<Entry />', () => {
-  it('renders', () => {
-    shallow(<Entry />);
-  });
-
   it('renders with plain old DOM element child', () => {
     mount(
       <Entry>

--- a/src/components/Input/story.tsx
+++ b/src/components/Input/story.tsx
@@ -1,4 +1,4 @@
-import React, { useState, InputHTMLAttributes } from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "dist",
+    "example",
+    "src/stories",
+    "src/**/story.tsx",
+    "src/**/*.story.tsx",
+    "src/**/*.test.tsx"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,12 +28,5 @@
     "isolatedModules": true
   },
   "include": ["src/global.d.ts", "src/**/*.ts", "src/**/*.tsx"],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "example",
-    "src/**/story.tsx",
-    "src/**/*.story.tsx",
-    "src/**/*.test.tsx"
-  ]
+  "exclude": ["node_modules", "dist", "example"]
 }


### PR DESCRIPTION
Currently, we exclude the story and test .ts and .tsx files to avoid including them in the final build. However, this means they are not properly typed during development.

This change ensures that everything is properly typed during development while excluding those files from being included in the final build through microbundle.