### PR TITLE
Support Date type for value, min, max

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "@testing-library/jest-dom": "^5.10.1",
     "@testing-library/react": "^10.2.1",
     "@testing-library/react-hooks": "^3.3.0",
+    "@testing-library/user-event": "^12.0.7",
     "@types/classnames": "^2.2.10",
     "@types/enzyme": "^3.10.5",
     "@types/jest": "^25.1.4",

--- a/src/components/InputTime/AsDate.tsx
+++ b/src/components/InputTime/AsDate.tsx
@@ -1,4 +1,5 @@
 import React, {
+  Fragment,
   MutableRefObject,
   useEffect,
   useImperativeHandle,
@@ -138,7 +139,7 @@ export const AsDate: React.FC<AsStringProps> = ({
   };
 
   return (
-    <>
+    <Fragment>
       <InputTimeAsString
         {...passedProps}
         disabled={invalidMax || invalidMin || disabled}
@@ -154,7 +155,7 @@ export const AsDate: React.FC<AsStringProps> = ({
         style={{ display: 'none' }}
         tabIndex={-1}
       />
-    </>
+    </Fragment>
   );
 };
 

--- a/src/components/InputTime/AsDate.tsx
+++ b/src/components/InputTime/AsDate.tsx
@@ -31,15 +31,24 @@ export const AsDate: React.FC<AsStringProps> = ({
 
   useEffect(() => {
     if (maxDateString && Number.isNaN(new Date(maxDateString).valueOf())) {
-      console.warn('`max` should be an ISO date string');
+      /* eslint-disable-next-line no-console */
+      console.warn(
+        '`max` should be an ISO date string when using `InputTime` with dates'
+      );
     }
 
     if (minDateString && Number.isNaN(new Date(minDateString).valueOf())) {
-      console.warn('`min` should be an ISO date string');
+      /* eslint-disable-next-line no-console */
+      console.warn(
+        '`min` should be an ISO date string when using `InputTime` with dates'
+      );
     }
 
     if (valueDateString && Number.isNaN(new Date(valueDateString).valueOf())) {
-      console.warn('`value` should be an ISO date string');
+      /* eslint-disable-next-line no-console */
+      console.warn(
+        '`value` should be an ISO date string when using `InputTime` with dates'
+      );
     }
   });
 

--- a/src/components/InputTime/AsDate.tsx
+++ b/src/components/InputTime/AsDate.tsx
@@ -1,0 +1,161 @@
+import React, {
+  MutableRefObject,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import {
+  getEndOfDay,
+  getShortTimeString,
+  getStartOfDay,
+  handleDispatchNativeInputChange,
+} from './utils';
+
+import InputTimeAsString, { AsStringProps } from './AsString';
+
+export const AsDate: React.FC<AsStringProps> = ({
+  disabled = false,
+  forwardedRef,
+  max: maxDateString,
+  min: minDateString,
+  onChange,
+  value: valueDateString,
+  ...passedProps
+}) => {
+  const [invalidMax, setInvalidMax] = useState(false);
+  const [invalidMin, setInvalidMin] = useState(false);
+
+  useEffect(() => {
+    if (maxDateString && Number.isNaN(new Date(maxDateString).valueOf())) {
+      console.warn('`max` should be an ISO date string');
+    }
+
+    if (minDateString && Number.isNaN(new Date(minDateString).valueOf())) {
+      console.warn('`min` should be an ISO date string');
+    }
+
+    if (valueDateString && Number.isNaN(new Date(valueDateString).valueOf())) {
+      console.warn('`value` should be an ISO date string');
+    }
+  });
+
+  const localRef = useRef<HTMLInputElement>(null) as MutableRefObject<
+    HTMLInputElement
+  >;
+
+  const shadowDateTimeInputRef = useRef<HTMLInputElement>(
+    null
+  ) as MutableRefObject<HTMLInputElement>;
+
+  useImperativeHandle(forwardedRef, () => localRef.current, []);
+
+  // If maxDate makes selected date 100% valid, all times are ok.
+  // Otherwise, parse it into a time string for InputTimeAsString
+  const max = useMemo(() => {
+    const maxDate = new Date(maxDateString || '');
+    const valueDate = new Date(valueDateString || '');
+    setInvalidMax(false);
+
+    if (
+      Number.isNaN(maxDate.valueOf()) ||
+      Number.isNaN(valueDate.valueOf()) ||
+      maxDate > getEndOfDay(valueDate)
+    ) {
+      return '';
+    }
+
+    if (maxDate < getStartOfDay(valueDate)) {
+      setInvalidMax(true);
+      return '';
+    }
+
+    return getShortTimeString(maxDate.getHours(), maxDate.getMinutes());
+  }, [maxDateString, valueDateString]);
+
+  // If minDateString makes selected date 100% valid, all times are ok.
+  // Otherwise, parse it into a time string for InputTimeAsString
+  const min = useMemo(() => {
+    const minDate = new Date(minDateString || '');
+    const valueDate = new Date(valueDateString || '');
+    setInvalidMin(false);
+
+    if (
+      Number.isNaN(minDate.valueOf()) ||
+      Number.isNaN(valueDate.valueOf()) ||
+      minDate < getStartOfDay(valueDate)
+    ) {
+      return '';
+    }
+
+    if (minDate > getEndOfDay(valueDate)) {
+      setInvalidMin(true);
+      return '';
+    }
+
+    return getShortTimeString(minDate.getHours(), minDate.getMinutes());
+  }, [minDateString, valueDateString]);
+
+  const value = useMemo(() => {
+    const valueDate = new Date(valueDateString || '');
+
+    if (Number.isNaN(valueDate.valueOf())) {
+      return '';
+    }
+
+    return getShortTimeString(valueDate.getHours(), valueDate.getMinutes());
+  }, [valueDateString]);
+
+  const handleChangeString = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!onChange) {
+      return;
+    }
+
+    let nextDate = new Date(valueDateString || '');
+
+    nextDate = Number.isNaN(nextDate.valueOf()) ? new Date() : nextDate;
+
+    if (e.target.value) {
+      const [hoursString, minutesString] = e.target.value.split(':');
+      nextDate.setHours(parseInt(hoursString, 10));
+      nextDate.setMinutes(parseInt(minutesString, 10));
+      nextDate.setSeconds(0);
+      nextDate.setMilliseconds(0);
+      const nextDateString = nextDate.toISOString();
+
+      if (
+        nextDateString !== valueDateString &&
+        shadowDateTimeInputRef.current
+      ) {
+        handleDispatchNativeInputChange(
+          shadowDateTimeInputRef.current,
+          nextDateString
+        );
+      }
+    }
+  };
+
+  return (
+    <>
+      <InputTimeAsString
+        {...passedProps}
+        disabled={invalidMax || invalidMin || disabled}
+        forwardedRef={localRef}
+        max={max}
+        min={min}
+        onChange={handleChangeString}
+        value={value}
+      />
+      <input
+        onChange={onChange || (() => {})}
+        ref={shadowDateTimeInputRef}
+        style={{ display: 'none' }}
+        tabIndex={-1}
+      />
+    </>
+  );
+};
+
+export default AsDate;

--- a/src/components/InputTime/AsString.tsx
+++ b/src/components/InputTime/AsString.tsx
@@ -1,0 +1,122 @@
+import React, {
+  Fragment,
+  RefObject,
+  MutableRefObject,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import Input, { InputProps } from '../Input';
+
+import {
+  getLocaleTimeStringFromShortTimeString,
+  guessTimeFromString,
+  handleDispatchNativeInputChange,
+} from './utils';
+
+const syncValidity = (
+  refFrom?: RefObject<HTMLInputElement>,
+  refTo?: RefObject<HTMLInputElement>
+) => {
+  if (refTo?.current && refFrom?.current) {
+    refTo.current.setCustomValidity(refFrom.current.validationMessage);
+  }
+};
+
+export interface AsStringProps
+  extends Omit<InputProps, 'value' | 'max' | 'min'> {
+  max?: string;
+  min?: string;
+  value?: string;
+}
+
+const AsString: React.FC<AsStringProps> = ({
+  forwardedRef,
+  max,
+  min,
+  onChange,
+  value: valueOrUndefined,
+  ...passedProps
+}) => {
+  const localRef = useRef<HTMLInputElement>(null) as MutableRefObject<
+    HTMLInputElement
+  >;
+
+  const shadowTimeInputRef = useRef<HTMLInputElement>(null) as MutableRefObject<
+    HTMLInputElement
+  >;
+
+  useImperativeHandle(forwardedRef, () => localRef.current, []);
+
+  // value is the true, controlled value, patched for undefined / empty
+  const value = useMemo(() => valueOrUndefined || '', [valueOrUndefined]);
+
+  // Fuzzy value is user input.
+  const [fuzzyValue, setFuzzyValue] = useState(
+    value ? getLocaleTimeStringFromShortTimeString(value) : ''
+  );
+
+  const handleChangeFuzzyValue = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFuzzyValue(e.target.value);
+
+    if (e.target.value) {
+      const { time: nextValue } = guessTimeFromString(e.target.value);
+
+      if (nextValue && nextValue !== value && shadowTimeInputRef.current) {
+        handleDispatchNativeInputChange(shadowTimeInputRef.current, nextValue);
+      }
+    }
+  };
+
+  const handleBlurFuzzyValue = () => {
+    setFuzzyValue(value ? getLocaleTimeStringFromShortTimeString(value) : '');
+  };
+
+  // Sync shadow input and fuzzy input to controlled value
+  useEffect(() => {
+    if (shadowTimeInputRef.current) {
+      handleDispatchNativeInputChange(shadowTimeInputRef.current, value);
+    }
+
+    if (localRef?.current && document.activeElement !== localRef?.current) {
+      setFuzzyValue(value ? getLocaleTimeStringFromShortTimeString(value) : '');
+    }
+
+    syncValidity(shadowTimeInputRef, localRef);
+  }, [localRef, value]);
+
+  // Sync validity on min/max changes
+  useEffect(() => {
+    syncValidity(shadowTimeInputRef, localRef);
+  }, [localRef, max, min]);
+
+  return (
+    <Fragment>
+      <Input
+        {...passedProps}
+        value={fuzzyValue}
+        ref={localRef}
+        onBlur={handleBlurFuzzyValue}
+        onChange={handleChangeFuzzyValue}
+      />
+      {/*
+        Shadow input for storing and dispatching change events to model
+        value (as opposed to the fuzzy value)
+      */}
+      <input
+        max={max}
+        min={min}
+        onChange={onChange || (() => {})}
+        ref={shadowTimeInputRef}
+        style={{ display: 'none' }}
+        tabIndex={-1}
+        type="time"
+      />
+    </Fragment>
+  );
+};
+
+export default AsString;

--- a/src/components/InputTime/InputTime.module.css
+++ b/src/components/InputTime/InputTime.module.css
@@ -1,3 +1,0 @@
-.InputTime {
-  visibility: visible;
-}

--- a/src/components/InputTime/InputTime.test.tsx
+++ b/src/components/InputTime/InputTime.test.tsx
@@ -1,7 +1,26 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import InputTime from './InputTime';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const WithUseRef = ({ Component, focus = false, ...passedProps }) => {
+  const ref = useRef<any>(null);
+
+  useEffect(() => {
+    if (ref && ref.current) {
+      if (focus) {
+        ref.current.focus();
+      } else {
+        ref.current.blur();
+      }
+    }
+  }, [focus]);
+
+  return <Component ref={ref} {...passedProps} />;
+};
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 describe('InputTime', () => {
   it('renders', () => {
@@ -14,27 +33,361 @@ describe('InputTime', () => {
     expect(baseInputTime.value).toBe('');
   });
 
-  describe('Handles fuzzy values', () => {
-    it("doesn't fire change callback without a valid input", () => {
+  describe('Handles bad values gracefully', () => {
+    it("With bad user input, doesn't fire change callback", () => {
       const handleChange = jest.fn((e) => e.target.value);
       const userInput = 'foo';
 
       const { getByLabelText } = render(
+        <InputTime aria-label="time input" onChange={handleChange} value="" />
+      );
+
+      const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+      userEvent.type(baseInputTime, userInput);
+      expect(baseInputTime.value).toBe(userInput);
+      expect(handleChange.mock.calls.length).toBe(0);
+    });
+
+    describe("With bad controlled values, doesn't fail", () => {
+      it('undefined', () => {
+        const { getByLabelText } = render(
+          <InputTime aria-label="time input" />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+        expect(baseInputTime.value).toBe('');
+      });
+
+      it('empty string', () => {
+        const { getByLabelText } = render(
+          <InputTime aria-label="time input" value="" />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+        expect(baseInputTime.value).toBe('');
+      });
+
+      it('garbage', () => {
+        const { getByLabelText } = render(
+          <InputTime aria-label="time input" value="foo" />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+        expect(baseInputTime.value).toBe('');
+      });
+    });
+  });
+
+  describe('Supports ref forwarding', () => {
+    it('with useRef', () => {
+      const { getByLabelText, rerender } = render(
+        <WithUseRef aria-label="time input" Component={InputTime} value="" />
+      );
+
+      const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+      expect(baseInputTime).not.toBe(document.activeElement);
+
+      rerender(
+        <WithUseRef
+          aria-label="time input"
+          Component={InputTime}
+          focus
+          value=""
+        />
+      );
+
+      expect(baseInputTime).toBe(document.activeElement);
+    });
+
+    it('with React.createRef', () => {
+      const ref = React.createRef<any>();
+
+      const { getByLabelText } = render(
+        <InputTime aria-label="time input" ref={ref} value="" />
+      );
+
+      const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+      expect(baseInputTime).not.toBe(document.activeElement);
+      baseInputTime.focus();
+      expect(baseInputTime).toBe(document.activeElement);
+    });
+
+    it('with callback refs', () => {
+      const handleSetRef = jest.fn(() => {});
+      render(<InputTime aria-label="time input" ref={handleSetRef} value="" />);
+
+      const {
+        mock: { calls },
+      } = handleSetRef;
+
+      let firstArgs: any = calls.length ? calls[0] : [];
+      firstArgs = firstArgs.length ? firstArgs[0] : null;
+      expect(handleSetRef.mock.calls.length).toBe(1);
+      expect(firstArgs.toString()).toBe('[object HTMLInputElement]');
+    });
+  });
+
+  describe('when passed ISO dates', () => {
+    it('Handles several time string patterns', () => {
+      const inputOutputMap = {
+        '1': {
+          hours: 1,
+          minutes: 0,
+        },
+        '1 p': {
+          hours: 13,
+          minutes: 0,
+        },
+        '3 15': {
+          hours: 3,
+          minutes: 15,
+        },
+        '3 15 pm': {
+          hours: 15,
+          minutes: 15,
+        },
+        '00:00': {
+          hours: 0,
+          minutes: 0,
+        },
+        '12:00': {
+          hours: 12,
+          minutes: 0,
+        },
+        '12 a': {
+          hours: 0,
+          minutes: 0,
+        },
+        '12 p': {
+          hours: 12,
+          minutes: 0,
+        },
+        '7h42': {
+          hours: 7,
+          minutes: 42,
+        },
+        '8,19p': {
+          hours: 20,
+          minutes: 19,
+        },
+      };
+
+      const handleChange = jest.fn((e) => e.target.value);
+
+      const { getByLabelText } = render(
         <InputTime
           aria-label="time input"
-          placeholder="Type a time"
           onChange={handleChange}
+          value="2020-06-29T20:00:00.000Z"
         />
       );
 
       const baseInputTime = getByLabelText('time input') as HTMLInputElement;
 
-      fireEvent.input(baseInputTime, { target: { value: userInput } });
-      expect(baseInputTime.value).toBe(userInput);
-      expect(handleChange.mock.calls.length).toBe(0);
+      Object.entries(inputOutputMap).forEach(([input, output], i) => {
+        /*
+            Don't use `userEvent.type()`` here because typing "3:15 pm" sets the
+            value multiple times, with 03:00, 03:10, 03:15, and 15:15 values
+          */
+        fireEvent.input(baseInputTime, { target: { value: input } });
+        expect(baseInputTime.value).toBe(input);
+        expect(handleChange.mock.calls.length).toBe(i + 1);
+        const selectedDate = new Date(handleChange.mock.results[i].value);
+        expect(selectedDate.getHours()).toBe(output.hours);
+        expect(selectedDate.getMinutes()).toBe(output.minutes);
+      });
     });
 
-    it('Handles various values', () => {
+    describe('validation', () => {
+      it('validates `value` against same day `min` and `max`', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime
+            aria-label="time input"
+            max="2020-06-29T20:00:00.000Z"
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+
+        // Equals `max`
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+        expect(baseInputTime.validationMessage).toBeFalsy();
+
+        // Equals `min`
+        rerender(
+          <InputTime
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T10:00:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeFalsy();
+
+        // Outside `max`
+        rerender(
+          <InputTime
+            max="2020-06-29T20:00:00.000Z"
+            value="2020-06-29T20:01:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeTruthy();
+
+        // Outside `min`
+        rerender(
+          <InputTime
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T09:59:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeTruthy();
+
+        // Impossible
+        rerender(
+          <InputTime
+            max="2020-06-29T09:59:00.000Z"
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T09:59:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeTruthy();
+      });
+
+      it('disables when `min` or `max` make all selections impossible', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime
+            aria-label="time input"
+            max="2020-06-29T20:00:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+
+        // Happy path
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+        expect(baseInputTime.disabled).toBeFalsy();
+
+        // `max` is before today
+        rerender(
+          <InputTime
+            max="2020-06-28T20:00:00.000Z"
+            min="2020-06-29T20:00:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+
+        expect(baseInputTime.disabled).toBeTruthy();
+
+        // `min` is after today
+        rerender(
+          <InputTime
+            max="2020-06-29T20:00:00.000Z"
+            min="2020-06-30T20:00:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+
+        expect(baseInputTime.disabled).toBeTruthy();
+
+        // `min` and `max are both impossible`
+        rerender(
+          <InputTime
+            max="2020-06-28T20:00:00.000Z"
+            min="2020-06-30T10:00:00.000Z"
+            value="2020-06-29T09:59:00.000Z"
+          />
+        );
+
+        expect(baseInputTime.disabled).toBeTruthy();
+
+        // Back to good
+        rerender(<InputTime value="2020-06-29T20:00:00.000Z" />);
+        expect(baseInputTime.disabled).toBeFalsy();
+      });
+
+      it('re-validates on `value` changes', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime
+            aria-label="time input"
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T10:00:00.000Z"
+          />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+        rerender(
+          <InputTime
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T09:59:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeTruthy();
+        rerender(
+          <InputTime
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T10:01:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeFalsy();
+      });
+
+      it('re-validates on `max` changes', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime
+            aria-label="time input"
+            max="2020-06-29T20:00:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+        rerender(
+          <InputTime
+            max="2020-06-29T19:59:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeTruthy();
+        rerender(
+          <InputTime
+            max="2020-06-29T20:01:00.000Z"
+            value="2020-06-29T20:00:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeFalsy();
+      });
+
+      it('re-validates on `min` changes', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime
+            aria-label="time input"
+            min="2020-06-29T10:00:00.000Z"
+            value="2020-06-29T10:00:00.000Z"
+          />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+        rerender(
+          <InputTime
+            min="2020-06-29T10:01:00.000Z"
+            value="2020-06-29T10:00:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeTruthy();
+        rerender(
+          <InputTime
+            min="2020-06-29T09:59:00.000Z"
+            value="2020-06-29T10:00:00.000Z"
+          />
+        );
+        expect(baseInputTime.validationMessage).toBeFalsy();
+      });
+    });
+  });
+
+  describe('when passed string times', () => {
+    it('Handles several time string patterns', () => {
       const inputOutputMap = {
         '1': '01:00',
         '1 p': '13:00',
@@ -51,20 +404,92 @@ describe('InputTime', () => {
       const handleChange = jest.fn((e) => e.target.value);
 
       const { getByLabelText } = render(
-        <InputTime
-          aria-label="time input"
-          placeholder="Type a time"
-          onChange={handleChange}
-        />
+        <InputTime aria-label="time input" onChange={handleChange} value="" />
       );
 
       const baseInputTime = getByLabelText('time input') as HTMLInputElement;
 
-      Object.entries(inputOutputMap).forEach(([k, v], i) => {
-        fireEvent.input(baseInputTime, { target: { value: k } });
-        expect(baseInputTime.value).toBe(k);
+      Object.entries(inputOutputMap).forEach(([input, output], i) => {
+        /*
+          Don't use `userEvent.type()`` here because typing "3:15 pm" sets the
+          value multiple times, with 03:00, 03:10, 03:15, and 15:15 values
+        */
+        fireEvent.input(baseInputTime, { target: { value: input } });
+        expect(baseInputTime.value).toBe(input);
         expect(handleChange.mock.calls.length).toBe(i + 1);
-        expect(handleChange.mock.results[i].value).toBe(v);
+        expect(handleChange.mock.results[i].value).toBe(output);
+      });
+    });
+
+    describe('validation', () => {
+      it('validates `value` against `min` and `max`', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime
+            aria-label="time input"
+            max="20:00"
+            min="10:00"
+            value="20:00"
+          />
+        );
+
+        // Equals `max`
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+        expect(baseInputTime.validationMessage).toBeFalsy();
+
+        // Equals `min`
+        rerender(<InputTime min="10:00" value="10:00" />);
+        expect(baseInputTime.validationMessage).toBeFalsy();
+
+        // Outside `max`
+        rerender(<InputTime max="20:00" value="20:01" />);
+        expect(baseInputTime.validationMessage).toBeTruthy();
+
+        // Outside `min`
+        rerender(<InputTime min="10:00" value="09:59" />);
+        expect(baseInputTime.validationMessage).toBeTruthy();
+
+        // Impossible
+        rerender(<InputTime max="9:59" min="10:00" value="09:59" />);
+        expect(baseInputTime.validationMessage).toBeTruthy();
+      });
+
+      it('re-validates on `value` changes', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime aria-label="time input" min="10:00" value="10:00" />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+        rerender(<InputTime min="10:00" value="09:59" />);
+        expect(baseInputTime.validationMessage).toBeTruthy();
+        rerender(<InputTime min="10:00" value="10:01" />);
+        expect(baseInputTime.validationMessage).toBeFalsy();
+      });
+
+      it('re-validates on `max` changes', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime aria-label="time input" max="20:00" value="20:00" />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+        rerender(<InputTime max="19:59" value="20:00" />);
+        expect(baseInputTime.validationMessage).toBeTruthy();
+        rerender(<InputTime max="20:01" value="20:00" />);
+        expect(baseInputTime.validationMessage).toBeFalsy();
+      });
+
+      it('re-validates on `min` changes', () => {
+        const { getByLabelText, rerender } = render(
+          <InputTime aria-label="time input" min="10:00" value="10:00" />
+        );
+
+        const baseInputTime = getByLabelText('time input') as HTMLInputElement;
+
+        rerender(<InputTime min="10:01" value="10:00" />);
+        expect(baseInputTime.validationMessage).toBeTruthy();
+        rerender(<InputTime min="09:59" value="10:00" />);
+        expect(baseInputTime.validationMessage).toBeFalsy();
       });
     });
   });

--- a/src/components/InputTime/InputTime.tsx
+++ b/src/components/InputTime/InputTime.tsx
@@ -1,25 +1,8 @@
-import React, {
-  forwardRef,
-  Fragment,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { forwardRef } from 'react';
 
-import classNames from 'classnames';
-
-import Input, { InputProps } from '../Input';
-
-import {
-  getEndOfDay,
-  getShortTimeString,
-  getStartOfDay,
-  getLocaleTimeStringFromShortTimeString,
-  guessTimeFromString,
-} from './utils';
-
-import styles from './InputTime.module.css';
+import { InputProps } from '../Input';
+import InputTimeAsDate from './AsDate';
+import InputTimeAsString from './AsString';
 
 /*
 Desired features:
@@ -29,249 +12,37 @@ Desired features:
 */
 
 interface InputTimeProps extends Omit<InputProps, 'value' | 'max' | 'min'> {
-  max?: Date | string;
-  min?: Date | string;
-  value?: Date | string;
-}
-
-export const InputTime: React.FC<InputTimeProps> = ({
-  disabled: initDisabled,
-  forwardedRef,
-  max,
-  min,
-  value,
-  ...passedProps
-}) => {
-  let disabled = initDisabled;
-
-  if (value instanceof Date) {
-    const maxDate = max instanceof Date ? max : undefined;
-    const minDate = min instanceof Date ? min : undefined;
-    const now = new Date();
-
-    if (maxDate && maxDate < getStartOfDay(now)) {
-      disabled = true;
-    }
-
-    if (minDate && minDate > getEndOfDay(now)) {
-      disabled = true;
-    }
-
-    return (
-      <InputTimeDate
-        {...passedProps}
-        disabled={disabled}
-        max={maxDate}
-        min={minDate}
-        value={value}
-      />
-    );
-  }
-
-  const maxString = typeof max === 'string' ? max : undefined;
-  const minString = typeof min === 'string' ? min : undefined;
-  const valueString = typeof value === 'string' ? value : undefined;
-
-  return (
-    <InputTimeString
-      {...passedProps}
-      max={maxString}
-      min={minString}
-      value={valueString}
-    />
-  );
-};
-
-interface InputTimeDateProps extends Omit<InputProps, 'value' | 'max' | 'min'> {
-  max?: Date;
-  min?: Date;
-  value?: Date;
-}
-
-export const InputTimeDate: React.FC<InputTimeDateProps> = ({
-  max: maxDate,
-  min: minDate,
-  onChange,
-  value: valueDate,
-  ...passedProps
-}) => {
-  const now = new Date();
-
-  const max = useMemo(() => {
-    if (maxDate === undefined || maxDate === null) {
-      return '';
-    }
-
-    if (maxDate > getEndOfDay(now)) {
-      return '';
-    }
-
-    return getShortTimeString(maxDate.getHours(), maxDate.getMinutes());
-  }, [maxDate, now]);
-
-  const min = useMemo(() => {
-    if (minDate === undefined || minDate === null) {
-      return '';
-    }
-
-    if (minDate < getStartOfDay(now)) {
-      return '';
-    }
-
-    return getShortTimeString(minDate.getHours(), minDate.getMinutes());
-  }, [minDate, now]);
-
-  const value = useMemo(() => {
-    return valueDate !== undefined && valueDate !== null
-      ? getShortTimeString(valueDate.getHours(), valueDate.getMinutes())
-      : '';
-  }, [valueDate]);
-
-  return <InputTimeString {...passedProps} max={max} min={min} value={value} />;
-};
-
-interface InputTimeStringProps
-  extends Omit<InputProps, 'value' | 'max' | 'min'> {
   max?: string;
   min?: string;
   value?: string;
 }
 
-export const InputTimeString: React.FC<InputTimeStringProps> = ({
-  className = '',
-  forwardedRef = undefined,
+export const InputTime: React.FC<InputTimeProps> = ({
   max,
   min,
-  onChange,
   value,
   ...passedProps
 }) => {
-  const mainRef = useRef<HTMLInputElement | null>(null);
-  const shadowTimeInputRef = useRef<HTMLInputElement | null>(null);
+  const maxDate = max ? new Date(max) : undefined;
+  const minDate = min ? new Date(min) : undefined;
+  const valueDate = value ? new Date(value) : undefined;
 
-  const syncValidity = () => {
-    if (mainRef.current && shadowTimeInputRef.current) {
-      mainRef.current.setCustomValidity(
-        shadowTimeInputRef.current.validationMessage
-      );
-    }
-  };
-
-  useEffect(() => {
-    syncValidity();
-  }, [max, min]);
-
-  const valueString = useMemo(() => {
-    if (value === '') {
-      const now = new Date();
-      return getShortTimeString(now.getHours(), now.getMinutes());
-    }
-
-    return value;
-  }, [value]);
-
-  // Fuzzy value is user input.
-  const [fuzzyValue, setFuzzyValue] = useState(
-    valueString ? getLocaleTimeStringFromShortTimeString(valueString) : ''
-  );
-  /*
-    modelValue is a `hh:mm` formatted string to
-    conform to native input[type="time"] controls.
-  */
-  const [modelValue, setModelValue] = useState(valueString);
-
-  const handleChangeModelValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    // In fuzzy mode, the event is fired by a shadow input, and this condition
-    // syncs the validation state between shadow and visible inputs
-    if (mainRef.current !== e.target) {
-      syncValidity();
-    }
-
-    setModelValue(e.target.value);
-
-    if (onChange) {
-      onChange(e);
-    }
-  };
-
-  const handleChangeFuzzyValue = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setFuzzyValue(e.target.value);
-
-    if (e.target.value) {
-      const { time: nextModelValue } = guessTimeFromString(e.target.value);
-
-      // Need step logic
-      // If custom step set, pass it in.
-      // If auto-step set, pass it in.
-
-      if (
-        nextModelValue &&
-        nextModelValue !== modelValue &&
-        shadowTimeInputRef.current
-      ) {
-        /*
-          To dispatch a change programmatically from a native input,
-          you have to use a native input setter. Otherwise, React swallows it.
-          https://stackoverflow.com/a/46012210
-        */
-        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-          window.HTMLInputElement.prototype,
-          'value'
-        )?.set;
-
-        if (nativeInputValueSetter) {
-          nativeInputValueSetter.call(
-            shadowTimeInputRef.current,
-            nextModelValue
-          );
-          const passedEvent = new Event('input', { bubbles: true });
-          shadowTimeInputRef.current.dispatchEvent(passedEvent);
-        }
-      }
-    }
-  };
-
-  const handleBlurFuzzyValue = () => {
-    if (mainRef?.current?.checkValidity() === false) {
-      return;
-    }
-
-    if (modelValue) {
-      setFuzzyValue(getLocaleTimeStringFromShortTimeString(modelValue));
-    } else {
-      setFuzzyValue('');
-    }
-  };
+  if (valueDate && !Number.isNaN(valueDate.valueOf())) {
+    return (
+      <InputTimeAsDate
+        {...passedProps}
+        max={maxDate?.toISOString() ?? undefined}
+        min={minDate?.toISOString() ?? undefined}
+        value={valueDate?.toISOString() ?? undefined}
+      />
+    );
+  }
 
   return (
-    <Fragment>
-      <Input
-        {...passedProps}
-        value={fuzzyValue}
-        ref={typeof forwardedRef === 'function' ? forwardedRef : mainRef}
-        onBlur={handleBlurFuzzyValue}
-        onChange={handleChangeFuzzyValue}
-        className={classNames(styles.InputTime, className)}
-      />
-      {/*
-        Shadow input for storing and dispatching change events to model
-        value (as opposed to the fuzzy value)
-      */}
-      <input
-        max={max}
-        min={min}
-        onChange={handleChangeModelValue}
-        ref={shadowTimeInputRef}
-        style={{ display: 'none' }}
-        tabIndex={-1}
-        type="time"
-      />
-    </Fragment>
+    <InputTimeAsString {...passedProps} max={max} min={min} value={value} />
   );
 };
 
-export default forwardRef<HTMLInputElement, InputTimeStringProps>(
-  (props, ref) => {
-    return <InputTime {...props} forwardedRef={ref || undefined} />;
-  }
-);
+export default forwardRef<HTMLInputElement, InputTimeProps>((props, ref) => (
+  <InputTime {...props} forwardedRef={ref || undefined} />
+));

--- a/src/components/InputTime/InputTime.tsx
+++ b/src/components/InputTime/InputTime.tsx
@@ -251,7 +251,7 @@ export const InputTimeString: React.FC<InputTimeStringProps> = ({
         ref={typeof forwardedRef === 'function' ? forwardedRef : mainRef}
         onBlur={handleBlurFuzzyValue}
         onChange={handleChangeFuzzyValue}
-        className={classNames(styles.InputTimeString, className)}
+        className={classNames(styles.InputTime, className)}
       />
       {/*
         Shadow input for storing and dispatching change events to model

--- a/src/components/InputTime/README.md
+++ b/src/components/InputTime/README.md
@@ -12,7 +12,14 @@ Validation of times in HTML is handled for time-of-day only, and this component 
 
 On blur, the user's fuzzy input is replaced with a locale-based time string.
 
-Coming soon:
+### Date vs. Time mode
+
+You can pass `max`, `min`, and `value` as either time strings `"14:00"` or ISO date strings `2020-06-30T14:30:00.000Z"`.
+All 3 props should match, if present.
+
+The component will disabled the input if the entire selected date is outside the `min` and `max`. It will enable all times if the entire selected date is inside the `min` and `max`. Otherwise, it will do time-of-day validation normally.
+
+### Coming soon
 
 - Add an optional dropdown that lets the user select a time quickly
 - Add min/max support for date times (less than 10AM June 9)

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { boolean, text } from '@storybook/addon-knobs';
+import { boolean, date, text } from '@storybook/addon-knobs';
 
 import { Title, Wrap } from '../../stories/storybook-helpers';
 
+import { getShortTimeString } from './utils';
 import InputTime from '.';
 import Readme from './README.md';
 
@@ -58,17 +59,55 @@ storiesOf('Planets/InputTime', module)
   )
   .add(
     'Example',
-    () => (
-      <Wrap>
-        <Title>With string times for max, min, and value</Title>
-        <InteractiveInputTime
-          max={text('max', '20:00')}
-          min={text('min', '10:00')}
-          onChange={action('onChange string')}
-          value={`${new Date().getHours()}:${new Date().getMinutes()}`}
-        />
-      </Wrap>
-    ),
+    () => {
+      const now = new Date();
+      const valueDate = now;
+      const valueString = getShortTimeString(now.getHours(), now.getMinutes());
+
+      const defaultMaxDate = useMemo(() => {
+        const d = new Date();
+        d.setHours(20);
+        d.setMinutes(0);
+        d.setSeconds(0);
+        d.setMilliseconds(0);
+        return d;
+      }, []);
+
+      const defaultMinDate = useMemo(() => {
+        const d = new Date();
+        d.setHours(10);
+        d.setMinutes(0);
+        d.setSeconds(0);
+        d.setMilliseconds(0);
+        return d;
+      }, []);
+
+      const maxDate = new Date(date('max (Date)', defaultMaxDate));
+      const minDate = new Date(date('min (Date)', defaultMinDate));
+
+      return (
+        <>
+          <Wrap>
+            <Title>With string times for max, min, and value</Title>
+            <InteractiveInputTime
+              max={text('max', '20:00')}
+              min={text('min', '10:00')}
+              onChange={action('onChange string')}
+              value={valueString}
+            />
+          </Wrap>
+          <Wrap>
+            <Title>With Date times for max, min, and value</Title>
+            <InteractiveInputTime
+              max={maxDate}
+              min={minDate}
+              onChange={action('onChange date')}
+              value={valueDate}
+            />
+          </Wrap>
+        </>
+      );
+    },
     {
       info: {
         inline: false,

--- a/src/components/InputTime/utils.ts
+++ b/src/components/InputTime/utils.ts
@@ -6,6 +6,25 @@ const nullSafeMatch = (string: string, regExp: RegExp) => {
   return { content, index, endIndex };
 };
 
+export const getEndOfDay = (date: Date) => {
+  const endOfDay = new Date(date);
+  endOfDay.setDate(endOfDay.getDate() + 1);
+  endOfDay.setHours(0);
+  endOfDay.setMinutes(0);
+  endOfDay.setSeconds(0);
+  endOfDay.setMilliseconds(-1);
+  return endOfDay;
+};
+
+export const getStartOfDay = (date: Date) => {
+  const startOfDay = new Date(date);
+  startOfDay.setHours(0);
+  startOfDay.setMinutes(0);
+  startOfDay.setSeconds(0);
+  startOfDay.setMilliseconds(0);
+  return startOfDay;
+};
+
 export const getShortTimeString = (hours: number, minutes: number) =>
   `${hours < 10 ? '0' : ''}${hours || 0}:${minutes < 10 ? '0' : ''}${
     minutes || 0

--- a/src/components/InputTime/utils.ts
+++ b/src/components/InputTime/utils.ts
@@ -6,6 +6,28 @@ const nullSafeMatch = (string: string, regExp: RegExp) => {
   return { content, index, endIndex };
 };
 
+export const handleDispatchNativeInputChange = (
+  element: HTMLInputElement,
+  nextValue: string | Date
+) => {
+  /*
+    To dispatch a change programmatically from a native input,
+    you have to use a native input setter. Otherwise, React swallows it.
+    https://stackoverflow.com/a/46012210
+  */
+
+  const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value'
+  )?.set;
+
+  if (nativeInputValueSetter) {
+    nativeInputValueSetter.call(element, nextValue);
+    const passedEvent = new Event('input', { bubbles: true });
+    element.dispatchEvent(passedEvent);
+  }
+};
+
 export const getEndOfDay = (date: Date) => {
   const endOfDay = new Date(date);
   endOfDay.setDate(endOfDay.getDate() + 1);
@@ -33,13 +55,16 @@ export const getShortTimeString = (hours: number, minutes: number) =>
 export const getLocaleTimeStringFromShortTimeString = (value: string) => {
   const date = new Date();
   const [hours, minutes] = value.split(':');
+
   date.setHours(parseInt(hours, 10));
   date.setMinutes(parseInt(minutes, 10));
 
-  return date.toLocaleTimeString([], {
-    hour: 'numeric',
-    minute: '2-digit',
-  });
+  return !Number.isNaN(date.valueOf())
+    ? date.toLocaleTimeString([], {
+        hour: 'numeric',
+        minute: '2-digit',
+      })
+    : '';
 };
 
 export const guessTimeFromString = (string: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,6 +2234,13 @@
     "@babel/runtime" "^7.10.2"
     "@testing-library/dom" "^7.9.0"
 
+"@testing-library/user-event@^12.0.7":
+  version "12.0.7"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-12.0.7.tgz#6028d8de294ebd1cbf63812bc40f99e61b82f318"
+  integrity sha512-v/1DS6V6P5zJVq5HCC/NU93CQaqML+exslOOYRmE71ULvtOCS4Fv6A2wgBjIsEEecjZtdS2LF+KlrOK3KvVZBA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
Builds on the InputTime component, by allowing the user to pass in a ISO date string.

The use case is for pairing the time picker with a date picker in the future for date-time goodness.

1. parses the date value to get the expected time string format and passes it along.
2. for min and max dates: 
  a. discards min/max if the entire current day is valid
  b. disables the input if the entire current day is invalid
  c. parses and passes down the min/max if today is only partially valid.

