### PR TITLE
feat: InputTime dropdown menu has default max height of 10.5 rows

### DIFF
--- a/src/components/Dropdown/Menu/Menu.module.css
+++ b/src/components/Dropdown/Menu/Menu.module.css
@@ -11,6 +11,7 @@
   transition: opacity 200ms var(--rvr-easeInOutQuad);
   opacity: 0;
   display: block;
+  overflow-y: auto;
 }
 
 .entering {

--- a/src/components/Dropdown/story.tsx
+++ b/src/components/Dropdown/story.tsx
@@ -51,12 +51,15 @@ storiesOf('Star Systems/Dropdown', module)
     'Overview',
     () => (
       <Dropdown
-        className={text('className', '')}
+        className={text('className', 'm-5')}
         disabled={boolean('disabled', false)}
         isOpen={boolean('isOpen', false)}
         onToggle={action('onToggle')}
       >
         {text('children', 'Dropdown children')}
+        <Dropdown.Menu>
+          {text('Dropdown.Menu children', 'Dropdown menu children')}
+        </Dropdown.Menu>
       </Dropdown>
     ),
     {
@@ -102,6 +105,29 @@ storiesOf('Star Systems/Dropdown', module)
                 className: 'p-3',
               }}
               className="inline"
+            />
+          </div>
+          <div className="m-5">
+            <OpenableDropdown
+              buttonProps={{
+                children: "With `menuProps.style.max-height: '100px'`",
+              }}
+              className="inline"
+              menuProps={{
+                // Too lazy to type out a story example
+                /* eslint-disable @typescript-eslint/no-explicit-any, react/no-array-index-key */
+                children: new Array(20)
+                  .fill(null)
+                  .map((props: any, i: number) => (
+                    <div key={i} {...props}>
+                      Item {i + 1}
+                    </div>
+                  )),
+                /* eslint-enable @typescript-eslint/no-explicit-any, react/no-array-index-key */
+                style: {
+                  maxHeight: '100px',
+                },
+              }}
             />
           </div>
           <div className="m-5">

--- a/src/components/InputTime/AsString.tsx
+++ b/src/components/InputTime/AsString.tsx
@@ -29,6 +29,7 @@ import styles from './InputTime.module.css';
 
 export interface AsStringProps
   extends Omit<InputProps, 'value' | 'max' | 'min'> {
+  dropdownProps?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   formatTime?: (date: Date) => string;
   fuzzyInputProps?: InputProps;
   max?: string;
@@ -41,6 +42,7 @@ export interface AsStringProps
 const AsString: React.FC<AsStringProps> = ({
   className = '',
   disabled,
+  dropdownProps,
   fauxDisabled,
   formatTime,
   forwardedRef,
@@ -238,6 +240,7 @@ const AsString: React.FC<AsStringProps> = ({
             stepFrom={stepFrom}
             toggleAriaLabel={toggleAriaLabel}
             value={value}
+            {...dropdownProps}
           />
         )}
       </div>

--- a/src/components/InputTime/AsString.tsx
+++ b/src/components/InputTime/AsString.tsx
@@ -41,6 +41,7 @@ export interface AsStringProps
 const AsString: React.FC<AsStringProps> = ({
   className = '',
   disabled,
+  fauxDisabled,
   formatTime,
   forwardedRef,
   fuzzyInputProps = {},
@@ -206,6 +207,7 @@ const AsString: React.FC<AsStringProps> = ({
       <Input
         className={styles.Input}
         disabled={disabled}
+        fauxDisabled={fauxDisabled}
         onBlur={handleBlurFuzzyValue}
         onChange={handleChangeFuzzyValue}
         ref={localRef}
@@ -214,7 +216,9 @@ const AsString: React.FC<AsStringProps> = ({
       />
       <div className={styles.addons}>
         <Icon
-          className={styles.icon}
+          className={classNames(styles.icon, {
+            [styles.disabledIcon]: disabled || fauxDisabled,
+          })}
           fill="currentColor"
           height={16}
           name="clock"
@@ -223,8 +227,8 @@ const AsString: React.FC<AsStringProps> = ({
         />
         {showDropdown && (
           <Dropdown
-            className={styles.addons}
-            disabled={disabled}
+            className={styles.dropdown}
+            disabled={disabled || fauxDisabled}
             formatTime={formatTime}
             max={max}
             min={min}

--- a/src/components/InputTime/Dropdown/Dropdown.module.css
+++ b/src/components/InputTime/Dropdown/Dropdown.module.css
@@ -6,9 +6,13 @@
   margin-right: 0;
 }
 
-.dropdownToggle {
+.toggle {
   display: block;
   padding: 3px;
+}
+
+.menu {
+  max-height: calc(var(--rvr-space-lg) * 2 * 5.5); /* --rvr-space-lg * 2 is the height of one row. */
 }
 
 .menuItem {

--- a/src/components/InputTime/Dropdown/Dropdown.module.css
+++ b/src/components/InputTime/Dropdown/Dropdown.module.css
@@ -12,7 +12,9 @@
 }
 
 .menu {
-  max-height: calc(var(--rvr-space-lg) * 2 * 5.5); /* --rvr-space-lg * 2 is the height of one row. */
+  --item-height: calc(var(--rvr-space-lg) * 2);
+  --visible-items-before-scrolling: 5.5;
+  max-height: calc(var(--item-height) * var(--visible-items-before-scrolling));
 }
 
 .menuItem {

--- a/src/components/InputTime/Dropdown/Dropdown.tsx
+++ b/src/components/InputTime/Dropdown/Dropdown.tsx
@@ -39,12 +39,15 @@ const Dropdown: React.FC<DropdownProps> = ({
   disabled,
   formatTime,
   max,
+  menuProps,
   min,
   onSelectMenuItem,
+  passedProps,
   showDropdown,
   step: customStep,
   stepFrom,
   toggleAriaLabel = 'Toggle time dropdown',
+  toggleProps,
   value,
 }) => {
   const menuItems = useMemo(() => {
@@ -135,21 +138,29 @@ const Dropdown: React.FC<DropdownProps> = ({
   return (
     <EasyDropdown
       className={classNames(className, styles.Dropdown)}
+      defaultIsOpen={false}
       disabled={disabled}
       isOpen={
-        undefined /* Suppresses typescript lint warning about missing prop */
+        /*
+          Explicit `undefined` suppresses typescript lint warning about missing prop.
+          We want to pass undefined to preserve controlled behavior
+        */
+        undefined
       }
-      onToggle={() => {}}
-      toggleProps={{
-        disabled,
-      }}
-      defaultIsOpen={false}
       menuItems={menuItems}
-      menuProps={{ position: 'bottomLeft' }}
+      menuProps={{
+        className: styles.menu,
+        position: 'bottomLeft',
+        ...menuProps,
+      }}
+      onToggle={() => {}}
+      toggleProps={toggleProps}
+      {...passedProps}
     >
       <Button
         aria-label={toggleAriaLabel}
-        className={styles.dropdownToggle}
+        className={styles.toggle}
+        disabled={disabled}
         level="text"
         size="sm"
       >

--- a/src/components/InputTime/Dropdown/Dropdown.tsx
+++ b/src/components/InputTime/Dropdown/Dropdown.tsx
@@ -24,12 +24,14 @@ interface DropdownProps {
   disabled?: boolean;
   formatTime?: (date: Date) => string;
   max?: string;
+  menuProps?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   min?: string;
   onSelectMenuItem: Function;
   showDropdown?: 'click' | 'focus';
   step?: number;
   stepFrom?: string;
   toggleAriaLabel?: string;
+  toggleProps?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   value?: string;
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }

--- a/src/components/InputTime/InputTime.module.css
+++ b/src/components/InputTime/InputTime.module.css
@@ -27,3 +27,7 @@
 .icon:not(:last-child) {
   margin-right: 0;
 }
+
+.disabledIcon {
+  color: var(--rvr-gray-40);
+}

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -170,6 +170,14 @@ storiesOf('Planets/InputTime', module)
       return (
         <>
           <Wrap>
+            <Title>Required props only</Title>
+            <InteractiveInput
+              Component={InputTime}
+              onChange={action('onChange string')}
+              value={getShortTimeString(new Date().getHours(), 0)}
+            />
+          </Wrap>
+          <Wrap>
             <Title>With string times for max, min, and value</Title>
             <InteractiveInput
               Component={InputTime}
@@ -219,6 +227,15 @@ storiesOf('Planets/InputTime', module)
               onChange={action('onChange string')}
               showDropdown="none"
               step={step}
+              value={getShortTimeString(new Date().getHours(), 0)}
+            />
+          </Wrap>
+          <Wrap>
+            <Title>Disabled</Title>
+            <InteractiveInput
+              Component={InputTime}
+              disabled
+              onChange={action('onChange string')}
               value={getShortTimeString(new Date().getHours(), 0)}
             />
           </Wrap>

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -189,6 +189,18 @@ storiesOf('Planets/InputTime', module)
             />
           </Wrap>
           <Wrap>
+            <Title>
+              Override menu max-height with
+              `dropdownProps.menuProps.style.maxHeight`
+            </Title>
+            <InteractiveInput
+              Component={InputTime}
+              dropdownProps={{ menuProps: { style: { maxHeight: '115px' } } }}
+              onChange={action('onChange string')}
+              value={getShortTimeString(new Date().getHours(), 0)}
+            />
+          </Wrap>
+          <Wrap>
             <Title>With Date times for max, min, and value</Title>
             <InteractiveInput
               Component={InputTime}


### PR DESCRIPTION
fixes #249

Feature:
- Re-using existing functionality to pass `menuProps` to `EasyDropdown`.
 - `InputTime` takes `dropdownProps` which are passed to `InputTime/Dropdown`.
 - `InputTime/Dropdown` passes any `menuProps`, `toggleProps`, or top-level `passedProps` down to its children in the appropriate slots.
- By default, `InputTime/Dropdown` adds a CSS class to the internal `Dropdown.Menu` which limits the height to 5.5 rows.
- `Dropdown.Menu` has a default style of `overflow-y: auto` for scrolling.

Docs:
- Added some stories to document the new ability.

Fix:
- Fixed `InputTime`'s clock icon to use correct color when disabled.
- Fixed `InputTime`'s `fauxDisabled` prop to pass it down to the correct child, so that class has the desired visual effect.

