### PR TITLE
Input time with tz offset

### DIFF
--- a/src/components/InputTime/AsDate.tsx
+++ b/src/components/InputTime/AsDate.tsx
@@ -148,6 +148,17 @@ export const AsDate: React.FC<AsStringProps> = ({
       nextDate.setSeconds(0);
       nextDate.setMilliseconds(0);
 
+      /*
+        When the user is in a different time zone than specified by
+        `timeZoneOffset`, the valid options for single date will appear to be on
+        different calendar dates.
+
+        E.g. For a user in UTC, India's "04:30" and "05:30" options will be on
+        different dates.
+
+        Since the options never span more than 24 hours, this cheesy logic
+        works to force the selection into the correct date.
+      */
       if (nextDate > maxDate) {
         nextDate.setDate(nextDate.getDate() - 1);
       }

--- a/src/components/InputTime/Dropdown/Dropdown.tsx
+++ b/src/components/InputTime/Dropdown/Dropdown.tsx
@@ -30,6 +30,7 @@ interface DropdownProps {
   showDropdown?: 'click' | 'focus';
   step?: number;
   stepFrom?: string;
+  timeZoneOffset?: number | null;
   toggleAriaLabel?: string;
   toggleProps?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   value?: string;
@@ -48,6 +49,7 @@ const Dropdown: React.FC<DropdownProps> = ({
   showDropdown,
   step: customStep,
   stepFrom,
+  timeZoneOffset,
   toggleAriaLabel = 'Toggle time dropdown',
   toggleProps,
   value,
@@ -83,25 +85,32 @@ const Dropdown: React.FC<DropdownProps> = ({
       }, SECONDS_PER_HOUR);
     }
 
-    const current =
-      (stepFrom && getDateTimeFromShortTimeString(stepFrom)) ||
-      getStartOfDay(new Date());
-    const end = getEndOfDay(new Date());
+    const current = stepFrom
+      ? getDateTimeFromShortTimeString(stepFrom, { timeZoneOffset })
+      : getStartOfDay(new Date(), { timeZoneOffset });
+
+    const end = getEndOfDay(new Date(), { timeZoneOffset });
 
     const maxAttempts =
       // 1 day + 1 hour buffer for daylight savings, divided into 10-minute increments
       // because that's the shortest step the dropdown supports
       (SECONDS_PER_HOUR + SECONDS_PER_DAY) / (SECONDS_PER_MINUTE * 10);
 
-    const maxDate = max ? getDateTimeFromShortTimeString(max) : undefined;
-    const minDate = min ? getDateTimeFromShortTimeString(min) : undefined;
-    let attempts = 0;
+    const maxDate = max
+      ? getDateTimeFromShortTimeString(max, { timeZoneOffset })
+      : undefined;
+
+    const minDate = min
+      ? getDateTimeFromShortTimeString(min, { timeZoneOffset })
+      : undefined;
 
     const options: {
       className: string;
       label: string;
       onClick: Function;
     }[] = [];
+
+    let attempts = 0;
 
     do {
       attempts += 1;
@@ -139,6 +148,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     onSelectMenuItem,
     showDropdown,
     stepFrom,
+    timeZoneOffset,
     value,
   ]);
 

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -212,6 +212,17 @@ storiesOf('Planets/InputTime', module)
             />
           </Wrap>
           <Wrap>
+            <Title>With a custom `formatTime` function</Title>
+            <InteractiveInput
+              Component={InputTime}
+              formatTime={(date: Date) =>
+                `${date.getHours()}🎈:${date.getMinutes()}🐝`
+              }
+              onChange={action('onChange date')}
+              value={getShortTimeString({ hours: new Date().getHours() })}
+            />
+          </Wrap>
+          <Wrap>
             <Title>
               With a custom `formatTime` function and a `timezoneOffset` prop
             </Title>

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -174,7 +174,7 @@ storiesOf('Planets/InputTime', module)
             <InteractiveInput
               Component={InputTime}
               onChange={action('onChange string')}
-              value={getShortTimeString(new Date().getHours(), 0)}
+              value={getShortTimeString({ hours: new Date().getHours() })}
             />
           </Wrap>
           <Wrap>
@@ -185,7 +185,7 @@ storiesOf('Planets/InputTime', module)
               min={text('min', '10:00', 'Using times')}
               onChange={action('onChange string')}
               step={step}
-              value={getShortTimeString(new Date().getHours(), 0)}
+              value={getShortTimeString({ hours: new Date().getHours() })}
             />
           </Wrap>
           <Wrap>
@@ -197,7 +197,7 @@ storiesOf('Planets/InputTime', module)
               Component={InputTime}
               dropdownProps={{ menuProps: { style: { maxHeight: '115px' } } }}
               onChange={action('onChange string')}
-              value={getShortTimeString(new Date().getHours(), 0)}
+              value={getShortTimeString({ hours: new Date().getHours() })}
             />
           </Wrap>
           <Wrap>
@@ -212,14 +212,24 @@ storiesOf('Planets/InputTime', module)
             />
           </Wrap>
           <Wrap>
-            <Title>With a custom `formatTime` function</Title>
+            <Title>
+              With a custom `formatTime` function and a `timezoneOffset` prop
+            </Title>
             <InteractiveInput
               Component={InputTime}
-              formatTime={(date: Date) =>
-                `${date.getHours()}🎈:${date.getMinutes()}🐝`
-              }
+              formatTime={(date: Date) => {
+                return new Intl.DateTimeFormat('en-IN', {
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  timeZone: 'Asia/Calcutta',
+                  timeZoneName: 'long',
+                }).format(date);
+              }}
               onChange={action('onChange date')}
-              value={new Date().toISOString()}
+              step={3600}
+              style={{ width: '20em' }}
+              timeZoneOffset={330}
+              value="12:00"
             />
           </Wrap>
           <Wrap>
@@ -239,7 +249,7 @@ storiesOf('Planets/InputTime', module)
               onChange={action('onChange string')}
               showDropdown="none"
               step={step}
-              value={getShortTimeString(new Date().getHours(), 0)}
+              value={getShortTimeString({ hours: new Date().getHours() })}
             />
           </Wrap>
           <Wrap>
@@ -248,7 +258,7 @@ storiesOf('Planets/InputTime', module)
               Component={InputTime}
               disabled
               onChange={action('onChange string')}
-              value={getShortTimeString(new Date().getHours(), 0)}
+              value={getShortTimeString({ hours: new Date().getHours() })}
             />
           </Wrap>
           <Wrap>


### PR DESCRIPTION
The `InputTime` component lets you pick a time of day.
Depending on the props passed in, it uses a min/max/value of either simple time of day strings ("10:00") or ISO date strings.

It validates selections against the `min` and `max`, and it also creates a dropdown menu with pre-populated options based on them.

The new functionality lets you pass in a target `timeZoneOffset`, e.g. the user is selecting times for IST (India Standard Time), which is +5:30 from UCT.
* The functions that detect start of day, end of day to build dropdown options do the right thing.
* We correctly determine if the `min` / `max` dates (in date mode) encompasses the selected date in India, so the validation can detect whether all or only some times are valid for a passed-in ISO date string.
* The configured `step` prop correctly validates using India's `min` or start of day. So 10:30 UTC is a valid option for India with no `min` and a `step` of 1 hour.