### PR TITLE
fix: min max validation without native input[type=time] support

### DIFF
--- a/src/components/InputTime/utils.test.tsx
+++ b/src/components/InputTime/utils.test.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import {
-  handleDispatchNativeInputChange,
-  guessTimeFromString,
-  getStartOfDay,
-  getShortTimeString,
-  getLocaleTimeStringFromShortTimeString,
-  getEndOfDay,
   getDateTimeFromShortTimeString,
+  getEndOfDay,
+  getInputTimeMinMaxValidationMessagePolyfill,
+  getLocaleTimeStringFromShortTimeString,
+  getShortTimeString,
+  getStartOfDay,
+  guessTimeFromString,
+  handleDispatchNativeInputChange,
 } from './utils';
 
 const getDayOfMonthFormat = ({ timeZoneName = 'America/Chicago' } = {}) => {
@@ -447,5 +448,78 @@ describe('guessTimeFromString', () => {
         });
       }
     );
+  });
+});
+
+describe('getInputTimeMinMaxValidationMessagePolyfill', () => {
+  it('handles validation with `max` and `min`', () => {
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        max: '20:00',
+        min: '10:00',
+        value: '15:00',
+      })
+    ).toBeFalsy();
+
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        max: '20:00',
+        min: '10:00',
+        value: '09:59',
+      })
+    ).toBeTruthy();
+
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        max: '20:00',
+        min: '10:00',
+        value: '20:01',
+      })
+    ).toBeTruthy();
+  });
+
+  it('handles validation with `max` only', () => {
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        max: '10:00',
+        value: '10:00',
+      })
+    ).toBeFalsy();
+
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        max: '10:00',
+        value: '10:01',
+      })
+    ).toBeTruthy();
+  });
+
+  it('handles validation with `min` only', () => {
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        min: '10:00',
+        value: '10:00',
+      })
+    ).toBeFalsy();
+
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        min: '10:00',
+        value: '09:59',
+      })
+    ).toBeTruthy();
+  });
+
+  it('handles validation without a `value`', () => {
+    expect(
+      getInputTimeMinMaxValidationMessagePolyfill({
+        max: '10:00',
+        min: '10:00',
+      })
+    ).toBeFalsy();
+  });
+
+  it('handles validation without anything', () => {
+    expect(getInputTimeMinMaxValidationMessagePolyfill({})).toBeFalsy();
   });
 });

--- a/src/components/InputTime/utils.ts
+++ b/src/components/InputTime/utils.ts
@@ -181,3 +181,34 @@ export const guessTimeFromString = (string: string) => {
   const time = getShortTimeString({ hours, minutes });
   return hasValidUserInput ? { time, hours, minutes } : {};
 };
+
+const getTotalMinutes = (timeString?: string) => {
+  const [hours, minutes] = (timeString || ':').split(':');
+  const totalMinutes = parseInt(hours, 10) * 60 + parseInt(minutes, 10);
+  return !Number.isNaN(totalMinutes) ? totalMinutes : undefined;
+};
+
+export const getInputTimeMinMaxValidationMessagePolyfill = ({
+  max,
+  min,
+  value,
+}: {
+  max?: string;
+  min?: string;
+  value?: string;
+}) => {
+  let validationMessage = '';
+  const totalMinutes = getTotalMinutes(value || ':');
+  const maxTotalMinutes = getTotalMinutes(max);
+  const minTotalMinutes = getTotalMinutes(min);
+
+  if (totalMinutes && maxTotalMinutes && totalMinutes > maxTotalMinutes) {
+    validationMessage = `Value must be ${max} or earlier.`;
+  }
+
+  if (totalMinutes && minTotalMinutes && totalMinutes < minTotalMinutes) {
+    validationMessage = `Value must be ${min} or later.`;
+  }
+
+  return validationMessage;
+};


### PR DESCRIPTION
Targeting a WIP branch for now, but this single commit should carry over easily after that's merged.

Safari doesn't support input with type="time" natively, alone among major browsers. That means the native validation wasn't working.

I wrote a pretty cheesy shim, at the basic `AsString` component, so `AsDate` should be fixed for free, and this doesn't require any time zone consideration.