### PR TITLE
Input time with tz offset pt 2

### DIFF
--- a/src/components/EasyDropdown/index.js
+++ b/src/components/EasyDropdown/index.js
@@ -16,7 +16,7 @@ const EasyDropdown = ({
   menuItems,
   menuProps,
   onToggle: parentOnToggle,
-  toggleProps,
+  toggleProps = {},
   ...passedProps
 }) => {
   const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(defaultIsOpen);
@@ -74,7 +74,7 @@ const EasyDropdown = ({
           ...toggleProps,
           className: classNames(
             child && child.props && child.props.className,
-            toggleProps.className
+            toggleProps && toggleProps.className
           ),
           'data-is-open': isOpen,
           onClick: (event) => {

--- a/src/components/InputTime/AsDate.tsx
+++ b/src/components/InputTime/AsDate.tsx
@@ -69,14 +69,20 @@ export const AsDate: React.FC<AsStringProps> = ({
   const max = useMemo(() => {
     const maxDate = new Date(maxDateString || '');
     const valueDate = new Date(valueDateString || '');
+    const endOfDay = getEndOfDay(valueDate, { timeZoneOffset });
     setInvalidMax(false);
 
     if (
       Number.isNaN(maxDate.valueOf()) ||
       Number.isNaN(valueDate.valueOf()) ||
-      maxDate > getEndOfDay(valueDate, { timeZoneOffset })
+      maxDate > endOfDay
     ) {
-      return '';
+      const endOfDayTime = getShortTimeString({
+        date: endOfDay,
+        timeZoneOffset,
+      });
+
+      return endOfDayTime;
     }
 
     if (maxDate < getStartOfDay(valueDate, { timeZoneOffset })) {
@@ -94,14 +100,20 @@ export const AsDate: React.FC<AsStringProps> = ({
   const min = useMemo(() => {
     const minDate = new Date(minDateString || '');
     const valueDate = new Date(valueDateString || '');
+    const startOfDay = getStartOfDay(valueDate, { timeZoneOffset });
     setInvalidMin(false);
 
     if (
       Number.isNaN(minDate.valueOf()) ||
       Number.isNaN(valueDate.valueOf()) ||
-      minDate < getStartOfDay(valueDate, { timeZoneOffset })
+      minDate < startOfDay
     ) {
-      return '';
+      const startOfDayTime = getShortTimeString({
+        date: startOfDay,
+        timeZoneOffset,
+      });
+
+      return startOfDayTime;
     }
 
     if (minDate > getEndOfDay(valueDate, { timeZoneOffset })) {
@@ -131,41 +143,15 @@ export const AsDate: React.FC<AsStringProps> = ({
       return;
     }
 
-    let nextDate = new Date(valueDateString || '');
-
-    nextDate = Number.isNaN(nextDate.valueOf()) ? new Date() : nextDate;
+    let date = new Date(valueDateString || '');
+    date = Number.isNaN(date.valueOf()) ? new Date() : date;
 
     if (e.target.value) {
-      const maxDate = new Date(maxDateString || '');
-      const minDate = new Date(minDateString || '');
-
-      const selectedTimeOfDay = getDateTimeFromShortTimeString(e.target.value, {
+      const nextDate = getDateTimeFromShortTimeString({
+        date,
+        time: e.target.value,
         timeZoneOffset,
       });
-
-      nextDate.setHours(selectedTimeOfDay.getHours());
-      nextDate.setMinutes(selectedTimeOfDay.getMinutes());
-      nextDate.setSeconds(0);
-      nextDate.setMilliseconds(0);
-
-      /*
-        When the user is in a different time zone than specified by
-        `timeZoneOffset`, the valid options for single date will appear to be on
-        different calendar dates.
-
-        E.g. For a user in UTC, India's "04:30" and "05:30" options will be on
-        different dates.
-
-        Since the options never span more than 24 hours, this cheesy logic
-        works to force the selection into the correct date.
-      */
-      if (nextDate > maxDate) {
-        nextDate.setDate(nextDate.getDate() - 1);
-      }
-
-      if (nextDate < minDate) {
-        nextDate.setDate(nextDate.getDate() + 1);
-      }
 
       const nextDateString = nextDate.toISOString();
 

--- a/src/components/InputTime/AsString.tsx
+++ b/src/components/InputTime/AsString.tsx
@@ -35,7 +35,6 @@ export interface AsStringProps
   min?: string;
   showDropdown?: 'click' | 'none' | null;
   timeZoneOffset?: number | null;
-  toggleAriaLabel?: string;
   value?: string;
 }
 
@@ -53,7 +52,6 @@ const AsString: React.FC<AsStringProps> = ({
   showDropdown: customShowDropdown = 'click',
   step: customStep,
   timeZoneOffset,
-  toggleAriaLabel,
   value: valueOrUndefined,
   ...passedProps
 }) => {
@@ -248,7 +246,6 @@ const AsString: React.FC<AsStringProps> = ({
             step={dropdownStep}
             stepFrom={stepFrom}
             timeZoneOffset={timeZoneOffset}
-            toggleAriaLabel={toggleAriaLabel}
             value={value}
             {...dropdownProps}
           />

--- a/src/components/InputTime/Dropdown/Dropdown.tsx
+++ b/src/components/InputTime/Dropdown/Dropdown.tsx
@@ -86,7 +86,7 @@ const Dropdown: React.FC<DropdownProps> = ({
     }
 
     const current = stepFrom
-      ? getDateTimeFromShortTimeString(stepFrom, { timeZoneOffset })
+      ? getDateTimeFromShortTimeString({ time: stepFrom, timeZoneOffset })
       : getStartOfDay(new Date(), { timeZoneOffset });
 
     const end = getEndOfDay(new Date(), { timeZoneOffset });
@@ -97,11 +97,11 @@ const Dropdown: React.FC<DropdownProps> = ({
       (SECONDS_PER_HOUR + SECONDS_PER_DAY) / (SECONDS_PER_MINUTE * 10);
 
     const maxDate = max
-      ? getDateTimeFromShortTimeString(max, { timeZoneOffset })
+      ? getDateTimeFromShortTimeString({ time: max, timeZoneOffset })
       : undefined;
 
     const minDate = min
-      ? getDateTimeFromShortTimeString(min, { timeZoneOffset })
+      ? getDateTimeFromShortTimeString({ time: min, timeZoneOffset })
       : undefined;
 
     const options: {

--- a/src/components/InputTime/Dropdown/Dropdown.tsx
+++ b/src/components/InputTime/Dropdown/Dropdown.tsx
@@ -31,8 +31,6 @@ interface DropdownProps {
   step?: number;
   stepFrom?: string;
   timeZoneOffset?: number | null;
-  toggleAriaLabel?: string;
-  toggleProps?: Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
   value?: string;
   [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
@@ -45,14 +43,13 @@ const Dropdown: React.FC<DropdownProps> = ({
   menuProps,
   min,
   onSelectMenuItem,
-  passedProps,
   showDropdown,
   step: customStep,
   stepFrom,
   timeZoneOffset,
-  toggleAriaLabel = 'Toggle time dropdown',
   toggleProps,
   value,
+  ...passedProps
 }) => {
   const menuItems = useMemo(() => {
     if (!showDropdown) {
@@ -171,11 +168,13 @@ const Dropdown: React.FC<DropdownProps> = ({
         ...menuProps,
       }}
       onToggle={() => {}}
-      toggleProps={toggleProps}
+      toggleProps={{
+        ...toggleProps,
+        'arial-label': toggleProps?.['aria-label'] || 'Toggle time dropdown',
+      }}
       {...passedProps}
     >
       <Button
-        aria-label={toggleAriaLabel}
         className={styles.toggle}
         disabled={disabled}
         level="text"

--- a/src/components/InputTime/InputTime.test.tsx
+++ b/src/components/InputTime/InputTime.test.tsx
@@ -146,10 +146,10 @@ describe('InputTime', () => {
     it('uses the custom formatter for the dropdown options', () => {
       const { getByLabelText, queryByText } = render(
         <InputTime
+          dropdownProps={{ toggleProps: { 'aria-label': 'Toggle' } }}
           formatTime={(date: Date) =>
             `${date.getHours()}🎈:${date.getMinutes()}🐝`
           }
-          toggleAriaLabel="Toggle"
         />
       );
 
@@ -173,7 +173,7 @@ describe('InputTime', () => {
           fuzzyInputProps={{ 'aria-label': 'time input' }}
           onChange={handleChange}
           value="11:00"
-          toggleAriaLabel="Toggle"
+          dropdownProps={{ toggleProps: { 'aria-label': 'Toggle' } }}
         />
       );
 
@@ -202,7 +202,7 @@ describe('InputTime', () => {
           <InputTime
             fuzzyInputProps={{ 'aria-label': 'time input' }}
             showDropdown={null}
-            toggleAriaLabel="Toggle"
+            dropdownProps={{ toggleProps: { 'aria-label': 'Toggle' } }}
           />
         );
 
@@ -213,7 +213,7 @@ describe('InputTime', () => {
           <InputTime
             fuzzyInputProps={{ 'aria-label': 'time input' }}
             showDropdown="none"
-            toggleAriaLabel="Toggle"
+            dropdownProps={{ toggleProps: { 'aria-label': 'Toggle' } }}
           />
         );
 
@@ -225,7 +225,7 @@ describe('InputTime', () => {
           <InputTime
             fuzzyInputProps={{ 'aria-label': 'time input' }}
             showDropdown="click"
-            toggleAriaLabel="Toggle"
+            dropdownProps={{ toggleProps: { 'aria-label': 'Toggle' } }}
           />
         );
 
@@ -235,7 +235,7 @@ describe('InputTime', () => {
         rerender(
           <InputTime
             fuzzyInputProps={{ 'aria-label': 'time input' }}
-            toggleAriaLabel="Toggle"
+            dropdownProps={{ toggleProps: { 'aria-label': 'Toggle' } }}
           />
         );
 

--- a/src/components/InputTime/InputTime.tsx
+++ b/src/components/InputTime/InputTime.tsx
@@ -12,7 +12,7 @@ Desired features:
    time field is focused
 */
 
-export const InputTime: React.FC<AsStringProps> = ({
+const InputTime: React.FC<AsStringProps> = ({
   max,
   min,
   value,

--- a/src/components/InputTime/README.md
+++ b/src/components/InputTime/README.md
@@ -12,6 +12,11 @@ Validation of times in HTML is handled for time-of-day only, and this component 
 
 On blur, the user's fuzzy input is replaced with a locale-based time string.
 
+For advanced customization, the component passes these arbitrary props objects down to child components:
+
+- `dropdownProps` is passed to the nested `EasyDropdown` time picker.
+- `fuzzyInputProps` is passed down to the child `Input` that's exposed to the user.
+
 ### Date vs. Time mode
 
 You can pass `max`, `min`, and `value` as either time strings `"14:00"` or ISO date strings `2020-06-30T14:30:00.000Z"`.
@@ -21,8 +26,8 @@ The component will disabled the input if the entire selected date is outside the
 
 ### Coming soon
 
-- Add an optional dropdown that lets the user select a time quickly
-  - Needs to center selection on current
+- For the optional time picker dropdown
+  - Should center selection on current
   - Should have keyboard support (up arrow / down arrow for iterating through menu items)
   - Dropdown should have "focus" mode, where the dropdown is always visible when the
     time field is focused

--- a/src/components/InputTime/index.ts
+++ b/src/components/InputTime/index.ts
@@ -1,1 +1,6 @@
-export { default, InputTime } from './InputTime';
+import AsDate from './AsDate';
+import AsString from './AsString';
+
+export const InputTimeAsDate = AsDate;
+export const InputTimeAsString = AsString;
+export { default } from './InputTime';

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -236,11 +236,13 @@ storiesOf('Planets/InputTime', module)
                   timeZoneName: 'long',
                 }).format(date);
               }}
+              max={text('max', defaultMaxDate, 'Using dates')}
+              min={text('min', defaultMinDate, 'Using dates')}
               onChange={action('onChange date')}
               step={3600}
               style={{ width: '20em' }}
               timeZoneOffset={330}
-              value="12:00"
+              value={defaultValueDate}
             />
           </Wrap>
           <Wrap>

--- a/src/components/InputTime/story.tsx
+++ b/src/components/InputTime/story.tsx
@@ -1,13 +1,12 @@
 import React, { useMemo, useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { boolean, number, select, text } from '@storybook/addon-knobs';
+import { boolean, number, object, select, text } from '@storybook/addon-knobs';
 
-import { Title, Wrap } from '../../stories/storybook-helpers';
+import { Spacer, Title, Wrap } from '../../stories/storybook-helpers';
 
 import Button from '../Button';
-import { getShortTimeString } from './utils';
-import InputTime from '.';
+import InputTime, { InputTimeAsDate, InputTimeAsString } from '.';
 import Readme from './README.md';
 
 const showDropdownOptions = {
@@ -89,13 +88,14 @@ storiesOf('Planets/InputTime', module)
       const valueDateString = text('value', defaultValueDate, 'Using dates');
       const maxString = text('max', '20:00', 'Using times');
       const minString = text('min', '10:00', 'Using times');
-      const valueString = text('value', '', 'Using times');
+      const valueString = text('value', '11:00', 'Using times');
 
       return (
         <InputTime
           className="m-8"
           disabled={boolean('disabled (HTML)', false, 'Common')}
           fauxDisabled={boolean('fauxDisabled', false, 'Common')}
+          fuzzyInputProps={object('fuzzyInputProps', {}, 'Common')}
           onChange={action('onChange (HTML)')}
           placeholder={text('placeholder(HTML)', 'Placeholder', 'Common')}
           max={useDates ? maxDateString : maxString}
@@ -126,6 +126,274 @@ storiesOf('Planets/InputTime', module)
   .add(
     'Examples',
     () => {
+      const maxDate = new Date();
+      maxDate.setHours(20);
+      maxDate.setMinutes(0);
+      maxDate.setSeconds(0);
+      maxDate.setMilliseconds(0);
+      const maxDateString = maxDate.toISOString();
+
+      const minDate = new Date();
+      minDate.setHours(10);
+      minDate.setMinutes(0);
+      minDate.setSeconds(0);
+      minDate.setMilliseconds(0);
+      const minDateString = minDate.toISOString();
+
+      const valueDate = new Date();
+      valueDate.setHours(11);
+      valueDate.setMinutes(0);
+      valueDate.setSeconds(0);
+      valueDate.setMilliseconds(0);
+      const valueDateString = valueDate.toISOString();
+
+      const ref = React.createRef<HTMLInputElement>();
+
+      const startOfNextHour = new Date();
+      startOfNextHour.setHours(startOfNextHour.getHours() + 1);
+      startOfNextHour.setMinutes(0);
+      startOfNextHour.setSeconds(0);
+      startOfNextHour.setMilliseconds(0);
+
+      return (
+        <>
+          <Wrap>
+            <Title>With string times</Title>
+            <div className="text-md mb-4 italic">
+              When passed time info in the format &ldquo;10:00&rdquo;,
+              `InputTime` relies on `InputTimeAsString`.
+              <br />
+              You could instead import `InputTimeAsString` directly.
+            </div>
+            <InteractiveInput Component={InputTime} value="11:00" />
+            <Spacer />
+            <div className="text-md mb-2">
+              With `max`, `min`, `step`, and `value`
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              max="20:00"
+              min="10:00"
+              step={900}
+              value="11:00"
+            />
+            <Spacer />
+            <div className="text-md mb-2">
+              Plus `formatTime`, `timezoneOffset`, and `style.width`
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              formatTime={(date: Date) =>
+                new Intl.DateTimeFormat('en-IN', {
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  timeZone: 'Asia/Calcutta',
+                  timeZoneName: 'long',
+                }).format(date)
+              }
+              max="20:00"
+              min="10:00"
+              step={900}
+              style={{ width: '20em' }}
+              value="11:00"
+            />
+          </Wrap>
+          <Wrap>
+            <Title>With Date times</Title>
+            <div className="text-md mb-4 italic">
+              When passed time info in the format
+              &ldquo;2020-08-20T12:00:00.000Z&rdquo;, `InputTime` relies on
+              `InputTimeAsDate`.
+              <br />
+              You could instead import `InputTimeAsDate` directly.
+            </div>
+            <InteractiveInput Component={InputTime} value={valueDateString} />
+            <Spacer />
+            <div className="text-md mb-2">
+              With `max`, `min`, `step`, and `value`
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              max={maxDateString}
+              min={minDateString}
+              step={900}
+              value={valueDateString}
+            />
+            <Spacer />
+            <div className="text-md mb-2">
+              Plus `formatTime`, `timezoneOffset`, and `style.width`
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              formatTime={(date: Date) =>
+                new Intl.DateTimeFormat('en-IN', {
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  timeZone: 'Asia/Calcutta',
+                  timeZoneName: 'long',
+                }).format(date)
+              }
+              max={maxDateString}
+              min={minDateString}
+              step={900}
+              style={{ width: '20em' }}
+              timeZoneOffset={330}
+              value={valueDateString}
+            />
+          </Wrap>
+          <Wrap>
+            <Title>Other use cases</Title>
+            <div className="text-md mb-2">
+              Requires you to pick a future date time
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              min={startOfNextHour.toISOString()}
+              step={3600}
+              value={startOfNextHour.toISOString()}
+            />
+            <Spacer />
+            <div className="text-md mb-2">
+              With a custom `formatTime` function
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              formatTime={(date: Date) =>
+                `${date.getHours()}🎈:${date.getMinutes()}🐝`
+              }
+              value="11:00"
+            />
+            <Spacer />
+            <div className="text-md mb-2">
+              Override menu max-height with `dropdownProps.menuProps`
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              dropdownProps={{ menuProps: { style: { maxHeight: '75px' } } }}
+              value="11:00"
+            />
+            <Spacer />
+            <div className="text-md mb-2">
+              Without the dropdown time selector
+            </div>
+            <InteractiveInput
+              Component={InputTime}
+              showDropdown="none"
+              value="11:00"
+            />
+            <Spacer />
+            <div className="text-md mb-2">Disabled</div>
+            <InteractiveInput Component={InputTime} disabled value="11:00" />
+            <Spacer />
+            <div className="text-md mb-2">Using a `ref` to control focus</div>
+            <InputTime ref={ref} value="11:00" />{' '}
+            {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+            <Button onClick={() => (ref.current as any)?.focus()}>
+              Focus!
+            </Button>
+          </Wrap>
+        </>
+      );
+    },
+    {
+      info: {
+        inline: false,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Advanced Date usage',
+    () => {
+      const defaultMaxDate = useMemo(() => {
+        const d = new Date();
+        d.setHours(11);
+        d.setMinutes(0);
+        d.setSeconds(0);
+        d.setMilliseconds(0);
+        return d.toISOString();
+      }, []);
+
+      const defaultMinDate = useMemo(() => {
+        const d = new Date();
+        d.setHours(0);
+        d.setMinutes(0);
+        d.setSeconds(0);
+        d.setMilliseconds(0);
+        return d.toISOString();
+      }, []);
+
+      const defaultValueDate = useMemo(() => {
+        const d = new Date();
+        d.setMinutes(0);
+        d.setSeconds(0);
+        d.setMilliseconds(0);
+        return d.toISOString();
+      }, []);
+
+      return (
+        <Wrap>
+          <Title>Advanced Date usage</Title>
+          <p className="text-sm">
+            <strong>
+              This component uses a custom `timeZoneOffset`, defaulted to India
+              Standard Time.
+            </strong>
+          </p>
+          <p className="text-sm">
+            The offset changes the interaction of min, max, and date values,
+            attempting to correctly populate the dropdown with time selections
+            from the current calendar day in the target time zone.
+          </p>
+          <p className="text-sm">
+            <strong>
+              This component uses a custom `formatTime` function based on
+              JavaScript&apos;s native `Intl.DateTimeFormat`.
+            </strong>
+          </p>
+          <p className="text-sm">
+            The formatter displays UTC times relative to a target time zone, in
+            a target language. Currently, it&apos;s set to Indian English and
+            the &ldquo;Asia/Calcutta&rdquo; time zone.
+          </p>
+          <InteractiveInput
+            Component={InputTime}
+            formatTime={(date: Date) =>
+              new Intl.DateTimeFormat('en-IN', {
+                hour: 'numeric',
+                minute: 'numeric',
+                timeZone: 'Asia/Calcutta',
+                timeZoneName: 'long',
+              }).format(date)
+            }
+            max={text('max', defaultMaxDate)}
+            min={text('min', defaultMinDate)}
+            onChange={action('onChange (HTML)')}
+            step={number('step (seconds)', 60 * 60, { min: 60, max: 60 * 60 })}
+            style={{ width: '20em' }}
+            timeZoneOffset={number('timeZoneOffset (minutes)', 330)}
+            value={text('value', defaultValueDate)}
+          />
+        </Wrap>
+      );
+    },
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  );
+
+storiesOf('Planets/InputTime/InputTimeAsDate', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => {
       const defaultMaxDate = useMemo(() => {
         const d = new Date();
         d.setHours(20);
@@ -152,14 +420,51 @@ storiesOf('Planets/InputTime', module)
         return d.toISOString();
       }, []);
 
-      const ref = React.createRef<HTMLInputElement>();
-
-      const step = number(
-        'step (seconds)',
-        60 * 60,
-        { min: 60, max: 60 * 60 },
-        'Common'
+      return (
+        <InputTimeAsDate
+          className="m-8"
+          disabled={boolean('disabled (HTML)', false)}
+          fauxDisabled={boolean('fauxDisabled', false)}
+          onChange={action('onChange (HTML)')}
+          placeholder={text('placeholder(HTML)', 'Placeholder')}
+          max={text('max', defaultMaxDate)}
+          min={text('min', defaultMinDate)}
+          showDropdown={select('showDropdown', showDropdownOptions, 'click')}
+          step={number('step (seconds)', 60 * 60, { min: 60, max: 60 * 60 })}
+          value={text('value', defaultValueDate)}
+        />
       );
+    },
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Examples',
+    () => {
+      const maxDate = new Date();
+      maxDate.setHours(20);
+      maxDate.setMinutes(0);
+      maxDate.setSeconds(0);
+      maxDate.setMilliseconds(0);
+      const maxDateString = maxDate.toISOString();
+
+      const minDate = new Date();
+      minDate.setHours(10);
+      minDate.setMinutes(0);
+      minDate.setSeconds(0);
+      minDate.setMilliseconds(0);
+      const minDateString = minDate.toISOString();
+
+      const valueDate = new Date();
+      valueDate.setHours(11);
+      valueDate.setMinutes(0);
+      valueDate.setSeconds(0);
+      valueDate.setMilliseconds(0);
+      const valueDateString = valueDate.toISOString();
 
       const startOfNextHour = new Date();
       startOfNextHour.setHours(startOfNextHour.getHours() + 1);
@@ -170,121 +475,126 @@ storiesOf('Planets/InputTime', module)
       return (
         <>
           <Wrap>
-            <Title>Required props only</Title>
+            <Title>With minimal props</Title>
             <InteractiveInput
-              Component={InputTime}
-              onChange={action('onChange string')}
-              value={getShortTimeString({ hours: new Date().getHours() })}
+              Component={InputTimeAsDate}
+              value={valueDateString}
             />
           </Wrap>
           <Wrap>
-            <Title>With string times for max, min, and value</Title>
+            <Title>With `max`, `min`, `step`, and `value`</Title>
             <InteractiveInput
-              Component={InputTime}
-              max={text('max', '20:00', 'Using times')}
-              min={text('min', '10:00', 'Using times')}
-              onChange={action('onChange string')}
-              step={step}
-              value={getShortTimeString({ hours: new Date().getHours() })}
+              Component={InputTimeAsDate}
+              max={maxDateString}
+              min={minDateString}
+              step={900}
+              value={valueDateString}
             />
           </Wrap>
           <Wrap>
             <Title>
-              Override menu max-height with
-              `dropdownProps.menuProps.style.maxHeight`
+              Plus `formatTime`, `timezoneOffset`, and `style.width`
             </Title>
             <InteractiveInput
-              Component={InputTime}
-              dropdownProps={{ menuProps: { style: { maxHeight: '115px' } } }}
-              onChange={action('onChange string')}
-              value={getShortTimeString({ hours: new Date().getHours() })}
-            />
-          </Wrap>
-          <Wrap>
-            <Title>With Date times for max, min, and value</Title>
-            <InteractiveInput
-              Component={InputTime}
-              max={text('max', defaultMaxDate, 'Using dates')}
-              min={text('min', defaultMinDate, 'Using dates')}
-              onChange={action('onChange date')}
-              step={step}
-              value={defaultValueDate}
-            />
-          </Wrap>
-          <Wrap>
-            <Title>With a custom `formatTime` function</Title>
-            <InteractiveInput
-              Component={InputTime}
+              Component={InputTimeAsDate}
               formatTime={(date: Date) =>
-                `${date.getHours()}🎈:${date.getMinutes()}🐝`
-              }
-              onChange={action('onChange date')}
-              value={getShortTimeString({ hours: new Date().getHours() })}
-            />
-          </Wrap>
-          <Wrap>
-            <Title>
-              With a custom `formatTime` function and a `timezoneOffset` prop
-            </Title>
-            <InteractiveInput
-              Component={InputTime}
-              formatTime={(date: Date) => {
-                return new Intl.DateTimeFormat('en-IN', {
+                new Intl.DateTimeFormat('en-IN', {
                   hour: 'numeric',
                   minute: 'numeric',
                   timeZone: 'Asia/Calcutta',
                   timeZoneName: 'long',
-                }).format(date);
-              }}
-              max={text('max', defaultMaxDate, 'Using dates')}
-              min={text('min', defaultMinDate, 'Using dates')}
-              onChange={action('onChange date')}
-              step={3600}
+                }).format(date)
+              }
+              max={maxDateString}
+              min={minDateString}
+              step={900}
               style={{ width: '20em' }}
               timeZoneOffset={330}
-              value={defaultValueDate}
+              value={valueDateString}
             />
           </Wrap>
+        </>
+      );
+    },
+    {
+      info: {
+        inline: false,
+        source: true,
+      },
+    }
+  );
+
+storiesOf('Planets/InputTime/InputTimeAsString', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => {
+      return (
+        <InputTimeAsString
+          className="m-8"
+          disabled={boolean('disabled (HTML)', false)}
+          fauxDisabled={boolean('fauxDisabled', false)}
+          fuzzyInputProps={object('fuzzyInputProps', {})}
+          onChange={action('onChange (HTML)')}
+          placeholder={text('placeholder(HTML)', 'Placeholder')}
+          max={text('max', '20:00')}
+          min={text('min', '10:00')}
+          showDropdown={select('showDropdown', showDropdownOptions, 'click')}
+          step={number('step (seconds)', 60 * 60, { min: 60, max: 60 * 60 })}
+          value={text('value', '11:00')}
+        />
+      );
+    },
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Examples',
+    () => {
+      return (
+        <>
           <Wrap>
-            <Title>Requires you to pick a future date time</Title>
+            <Title>With minimal props</Title>
+            <InteractiveInput Component={InputTimeAsString} value="11:00" />
+          </Wrap>
+          <Wrap>
+            <Title>With `max`, `min`, `step`, and `value`</Title>
             <InteractiveInput
-              Component={InputTime}
-              min={startOfNextHour.toISOString()}
-              onChange={action('onChange date')}
-              step={3600}
-              value={startOfNextHour.toISOString()}
+              Component={InputTimeAsString}
+              max="20:00"
+              min="10:00"
+              step={900}
+              value="11:00"
             />
           </Wrap>
           <Wrap>
-            <Title>Without the dropdown time selector</Title>
+            <Title>
+              Plus `formatTime`, `timezoneOffset`, and `style.width`
+            </Title>
             <InteractiveInput
-              Component={InputTime}
-              onChange={action('onChange string')}
-              showDropdown="none"
-              step={step}
-              value={getShortTimeString({ hours: new Date().getHours() })}
+              Component={InputTimeAsString}
+              formatTime={(date: Date) =>
+                new Intl.DateTimeFormat('en-IN', {
+                  hour: 'numeric',
+                  minute: 'numeric',
+                  timeZone: 'Asia/Calcutta',
+                  timeZoneName: 'long',
+                }).format(date)
+              }
+              max="20:00"
+              min="10:00"
+              step={900}
+              style={{ width: '20em' }}
+              value="11:00"
             />
-          </Wrap>
-          <Wrap>
-            <Title>Disabled</Title>
-            <InteractiveInput
-              Component={InputTime}
-              disabled
-              onChange={action('onChange string')}
-              value={getShortTimeString({ hours: new Date().getHours() })}
-            />
-          </Wrap>
-          <Wrap>
-            <Title>Using a `ref` to control focus</Title>
-            <InputTime ref={ref} value={new Date().toISOString()} />{' '}
-            <Button
-              onClick={() => {
-                /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-                (ref.current as any)?.focus();
-              }}
-            >
-              Focus!
-            </Button>
           </Wrap>
         </>
       );

--- a/src/components/InputTime/utils.test.tsx
+++ b/src/components/InputTime/utils.test.tsx
@@ -360,19 +360,20 @@ describe('getDateTimeFromShortTimeString', () => {
   it('turns hour and minute into a local date', () => {
     let date: Date;
 
-    date = getDateTimeFromShortTimeString('12:30');
+    date = getDateTimeFromShortTimeString({ time: '12:30' });
     expect(date.toLocaleTimeString('en-US')).toEqual('12:30:00 PM');
 
-    date = getDateTimeFromShortTimeString('00:30');
+    date = getDateTimeFromShortTimeString({ time: '00:30' });
     expect(date.toLocaleTimeString('en-US')).toEqual('12:30:00 AM');
 
-    date = getDateTimeFromShortTimeString('23:59');
+    date = getDateTimeFromShortTimeString({ time: '23:59' });
     expect(date.toLocaleTimeString('en-US')).toEqual('11:59:00 PM');
   });
 
   describe('with optional `timeZoneOffset`', () => {
     it('works for different time zones', () => {
-      const dateCDT = getDateTimeFromShortTimeString('12:30', {
+      const dateCDT = getDateTimeFromShortTimeString({
+        time: '12:30',
         timeZoneOffset: -300,
       });
 
@@ -381,7 +382,8 @@ describe('getDateTimeFromShortTimeString', () => {
         timeZoneName: 'America/Chicago',
       });
 
-      const dateIST = getDateTimeFromShortTimeString('12:30', {
+      const dateIST = getDateTimeFromShortTimeString({
+        time: '12:30',
         timeZoneOffset: +330,
       });
 

--- a/src/components/InputTime/utils.ts
+++ b/src/components/InputTime/utils.ts
@@ -99,32 +99,32 @@ export const getShortTimeString = (args?: GetShortTimeStringArgs) => {
   }${minutes}`;
 };
 
-export const getDateTimeFromShortTimeString = (
-  value: string,
-  options?: DateOptions
-) => {
-  const { timeZoneOffset } = options || {};
+interface GetDateTimeFromShortTimeStringArgs extends DateOptions {
+  time: string;
+  date?: Date;
+}
+
+export const getDateTimeFromShortTimeString = ({
+  date,
+  timeZoneOffset,
+  time,
+}: GetDateTimeFromShortTimeStringArgs) => {
   const tzOffset = getTimeZoneOffsetFromLocal(timeZoneOffset);
-  const date = new Date();
-  const [hours, minutes] = value.split(':');
-  date.setMinutes(date.getMinutes() + tzOffset);
-  date.setHours(parseInt(hours, 10));
-  date.setMinutes(parseInt(minutes, 10) - tzOffset);
-  date.setSeconds(0);
-  date.setMilliseconds(0);
-  return date;
+  const nextDate = date !== undefined ? new Date(date) : new Date();
+  const [hours, minutes] = time.split(':');
+  nextDate.setMinutes(nextDate.getMinutes() + tzOffset);
+  nextDate.setHours(parseInt(hours, 10));
+  nextDate.setMinutes(parseInt(minutes, 10) - tzOffset);
+  nextDate.setSeconds(0);
+  nextDate.setMilliseconds(0);
+  return nextDate;
 };
 
-export const getLocaleTimeStringFromShortTimeString = (
-  value: string,
+export const getLocaleTimeStringFromDate = (
+  date: Date,
   options?: TimeStringOptions
 ) => {
-  const { formatTime, locale, timeZoneOffset, ...passedOptions } =
-    options || {};
-
-  const date = getDateTimeFromShortTimeString(value, {
-    timeZoneOffset,
-  });
+  const { formatTime, locale, ...passedOptions } = options || {};
 
   return typeof formatTime === 'function'
     ? formatTime(date)
@@ -133,6 +133,20 @@ export const getLocaleTimeStringFromShortTimeString = (
         minute: '2-digit',
         ...passedOptions,
       });
+};
+
+export const getLocaleTimeStringFromShortTimeString = (
+  value: string,
+  options?: TimeStringOptions
+) => {
+  const { timeZoneOffset, ...passedOptions } = options || {};
+
+  const date = getDateTimeFromShortTimeString({
+    time: value,
+    timeZoneOffset,
+  });
+
+  return getLocaleTimeStringFromDate(date, passedOptions);
 };
 
 export const guessTimeFromString = (string: string) => {


### PR DESCRIPTION
- fixes an issue with min/max validation in the `AsDate` component.
- refactor: changes the interface for a few of the `InputTime/utils`, so there's a slight refactor there.
- Adds named export for `AsDate`: `InputTimeAsDate`
- Adds named export for `AsString`: `InputTimeAsString`
- docs: Most of the huge diff comes from updating the `InputTime` story to add sections for the `AsDate`/`AsString` components.