### PR TITLE
TypeScript and CSS custom prop fixes

### DIFF
--- a/src/components/EasyPill/EasyPill.tsx
+++ b/src/components/EasyPill/EasyPill.tsx
@@ -16,7 +16,7 @@ type EasyPillActions = {
 
 interface EasyPillProps extends PillProps {
   actions?: EasyPillActions[];
-  children: React.ReactNode;
+  children?: React.ReactNode;
   onDelete?: (...args) => void;
 }
 

--- a/src/components/InputTime/Dropdown/Dropdown.module.css
+++ b/src/components/InputTime/Dropdown/Dropdown.module.css
@@ -12,9 +12,7 @@
 }
 
 .menu {
-  --item-height: calc(var(--rvr-space-lg) * 2);
-  --visible-items-before-scrolling: 5.5;
-  max-height: calc(var(--item-height) * var(--visible-items-before-scrolling));
+  max-height: calc(var(--rvr-dropdown-menu-item-height) * var(--rvr-dropdown-menu-max-rows-sm));
 }
 
 .menuItem {

--- a/src/components/TabMenu/TabMenu.tsx
+++ b/src/components/TabMenu/TabMenu.tsx
@@ -74,6 +74,6 @@ export const EasyTabMenu: React.FC<EasyTabMenuProps> = ({
   );
 };
 
-export const SimpleTabMenu = TabMenu;
+export const SimpleTabMenu = EasyTabMenu;
 
 export default TabMenu;

--- a/src/components/TabMenu/TabMenu.tsx
+++ b/src/components/TabMenu/TabMenu.tsx
@@ -32,7 +32,7 @@ export type EasyTabType = {
   onClick: (e: React.SyntheticEvent) => void;
 };
 export interface EasyTabMenuProps extends TabMenuProps {
-  tabs?: EasyTabType[];
+  tabs?: Readonly<EasyTabType[]>;
   size?: 'xs' | 'sm' | 'md' | 'lg';
   activeTab?: string;
 }

--- a/src/components/TabMenu/TabMenu.tsx
+++ b/src/components/TabMenu/TabMenu.tsx
@@ -43,18 +43,13 @@ export const EasyTabMenu: React.FC<EasyTabMenuProps> = ({
   activeTab = '',
   size = 'md',
   ...props
-}) => {
-  const safeTabs: EasyTabType[] = [];
-
-  tabs.forEach((tab) => {
-    if (tab) {
-      safeTabs.push(tab);
-    }
-  });
-
-  return (
-    <TabMenu {...props}>
-      {safeTabs.map((tab) => {
+}) => (
+  <TabMenu {...props}>
+    {tabs
+      .filter(
+        (tab: EasyTabType | undefined): tab is EasyTabType => tab !== undefined
+      )
+      .map((tab) => {
         const inner = classNames(
           styles.itemPadding,
           styles[`${size}TextSize`],
@@ -70,9 +65,8 @@ export const EasyTabMenu: React.FC<EasyTabMenuProps> = ({
           </Item>
         );
       })}
-    </TabMenu>
-  );
-};
+  </TabMenu>
+);
 
 export const SimpleTabMenu = EasyTabMenu;
 

--- a/src/components/TabMenu/TabMenu.tsx
+++ b/src/components/TabMenu/TabMenu.tsx
@@ -31,8 +31,9 @@ export type EasyTabType = {
   label: string;
   onClick: (e: React.SyntheticEvent) => void;
 };
+
 export interface EasyTabMenuProps extends TabMenuProps {
-  tabs?: Readonly<EasyTabType[]>;
+  tabs?: Readonly<Array<EasyTabType | undefined>>;
   size?: 'xs' | 'sm' | 'md' | 'lg';
   activeTab?: string;
 }
@@ -43,9 +44,17 @@ export const EasyTabMenu: React.FC<EasyTabMenuProps> = ({
   size = 'md',
   ...props
 }) => {
+  const safeTabs: EasyTabType[] = [];
+
+  tabs.forEach((tab) => {
+    if (tab) {
+      safeTabs.push(tab);
+    }
+  });
+
   return (
     <TabMenu {...props}>
-      {tabs.map((tab) => {
+      {safeTabs.map((tab) => {
         const inner = classNames(
           styles.itemPadding,
           styles[`${size}TextSize`],
@@ -64,5 +73,7 @@ export const EasyTabMenu: React.FC<EasyTabMenuProps> = ({
     </TabMenu>
   );
 };
+
+export const SimpleTabMenu = TabMenu;
 
 export default TabMenu;

--- a/src/components/TabMenu/index.ts
+++ b/src/components/TabMenu/index.ts
@@ -1,1 +1,1 @@
-export { default, EasyTabMenu } from './TabMenu';
+export { default, EasyTabMenu, SimpleTabMenu } from './TabMenu';

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,11 @@ export { default as Pill } from './components/Pill';
 export { default as Responsive } from './components/Responsive';
 export { default as SideTray } from './components/SideTray';
 
-export { default as TabMenu, EasyTabMenu } from './components/TabMenu';
+export {
+  default as TabMenu,
+  EasyTabMenu,
+  SimpleTabMenu,
+} from './components/TabMenu';
 
 export { default as Tooltip, EasyRichTooltip } from './components/Tooltip';
 export { default as Input } from './components/Input';

--- a/src/shared/sizing.css
+++ b/src/shared/sizing.css
@@ -34,17 +34,7 @@
       var(--rvr-space-xl) - var(--rvr-border-width-md)
     );
 
-  /* TYPE */
-
-  /* Tooltip */
-  --rvr-tooltip-arrow-size: 6px;
-  --rvr-tooltip-border-size: 1px;
-  --rvr-tooltip-box-shadow:
-    0 1px 2px 0 rgba(0, 0, 0, 0.2),
-    0 5px 10px 0 rgba(0, 0, 0, 0.1);
-  --rvr-tooltip-base-z-index: 900;
-  --rvr-tooltip-border-radius: 3px;
-  --rvr-tooltip-offset: 20px;
+  /* TYPOGRAPHY */
 
   /* font-size */
   --rvr-font-size-base: 14px;
@@ -59,4 +49,21 @@
   --rvr-line-height-sm: calc(var(--rvr-baseSize) * 2); /* 16px */
   --rvr-line-height-md: calc(var(--rvr-baseSize) * 2.5); /* 20px */
   --rvr-line-height-lg: calc(var(--rvr-baseSize) * 3); /* 24px */
+
+  /* Tooltip */
+  --rvr-tooltip-arrow-size: 6px;
+  --rvr-tooltip-border-size: 1px;
+  --rvr-tooltip-box-shadow:
+    0 1px 2px 0 rgba(0, 0, 0, 0.2),
+    0 5px 10px 0 rgba(0, 0, 0, 0.1);
+  --rvr-tooltip-base-z-index: 900;
+  --rvr-tooltip-border-radius: 3px;
+  --rvr-tooltip-offset: 20px;
+
+  /* Dropdowns */
+  /* Default EasyDropdown menu item with text label */
+  --rvr-dropdown-menu-item-height: calc(var(--rvr-line-height-sm) + 2 * var(--rvr-space-sm));
+  /* Dropdown menu max height includes a half-row as a scrolling hint */
+  --rvr-dropdown-menu-max-rows-sm: 5.5;
+  --rvr-dropdown-menu-max-rows-md: 10.5;
 }


### PR DESCRIPTION
Fixes issues #267 and #268, plus a couple of undocumented bugs with the move to TS.

- Some CSS vars moved to shared sizing.css
- EasyPill handles undefined `children` prop
- EasyTabMenu allows readonly tabs prop, and handles undefined items in the tabs array
- Export SimpleTabMenu as an alias of EasyTabMenu for backwards compatibility 

This will need a new patch version before we can upgrade Cision FE code to use RoverUI again.