### PR TITLE
fix: wire up TabMenu.Item onClick handler

### DIFF
--- a/src/components/TabMenu/Item/Item.tsx
+++ b/src/components/TabMenu/Item/Item.tsx
@@ -26,7 +26,7 @@ const Item: React.FC<ItemProps> = ({
     [styles.active]: active || isChildActive(children),
   });
   return (
-    <li className={className} {...props}>
+    <li className={className} onClick={onClick} {...props}>
       {children}
     </li>
   );

--- a/src/components/TabMenu/TabMenu.test.tsx
+++ b/src/components/TabMenu/TabMenu.test.tsx
@@ -27,6 +27,18 @@ describe('TabMenu.Item', () => {
 
     expect(inactive.prop('active')).not.toBe(true);
   });
+
+  it('triggers onClick handler when clicking', () => {
+    const fakeClickHandler = jest.fn();
+    const menuItem = mount(
+      <TabMenu.Item onClick={fakeClickHandler}>
+        Clickable menu item
+      </TabMenu.Item>
+    );
+    menuItem.simulate('click');
+
+    expect(fakeClickHandler).toHaveBeenCalled();
+  });
 });
 
 describe('EasyTabMenu', () => {


### PR DESCRIPTION
fix: wire up TabMenu.Item onClick handler

Looks like there was an oversight when refactoring TabMenu.Item to TS. Formerly, this prop was just a passthrough prop. In moving from defaultProps to a "real" prop, we never wired up this now explicit prop to the clickable element, so we were just swallowing the click.
https://github.com/cision/rover-ui/commit/1744170aad4d216c03370f3ee34c5b575127d97d#diff-c2c666f90ee1074db732ccbd92d0c57b

Original JS:
```javascript
const Item = ({ className: customClassName, active, children, ...props }) => {
...
<li className={className} {...props}>
...
Item.defaultProps = {
  className: '',
  active: false,
  onClick: () => {},
};
```
became this TS:
```javascript
const Item: React.FC<ItemProps> = ({
  className: customClassName,
  active = false,
  children,
  onClick = () => {}, // <========= new prop
  ...props
}) => {
...
<li className={className} {...props}>

```
