### PR TITLE
TabMenu.Item follow-up: remove explicit onClick mapping

### DIFF
--- a/src/components/TabMenu/Item/Item.tsx
+++ b/src/components/TabMenu/Item/Item.tsx
@@ -11,7 +11,6 @@ const Item: React.FC<ItemProps> = ({
   className: customClassName,
   active = false,
   children,
-  onClick = () => {},
   ...props
 }) => {
   // NOTE: "Using the 'active' className on a TabMenu.Item child is deprecated. Use <TabMenu.Item active> instead."
@@ -26,7 +25,7 @@ const Item: React.FC<ItemProps> = ({
     [styles.active]: active || isChildActive(children),
   });
   return (
-    <li className={className} onClick={onClick} {...props}>
+    <li className={className} {...props}>
       {children}
     </li>
   );


### PR DESCRIPTION
Follow up to https://github.com/cision/rover-ui/pull/270

Remove explicit onClick mapping, since it provides no value, and ESLint wants keyboard handlers for our LI if we roll our own click handler