### PR TITLE
Removed attributes we don't need to explicitly define.

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -13,6 +13,7 @@ export interface InputProps
 
 const Input: React.FC<InputProps> = ({
   className = '',
+  onChange = () => {},
   fauxDisabled = false,
   forwardedRef: ref,
   ...passedProps
@@ -23,6 +24,7 @@ const Input: React.FC<InputProps> = ({
         [styles.disabled]: fauxDisabled,
       })}
       ref={ref || undefined}
+      onChange={onChange}
       {...passedProps}
     />
   );

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -13,8 +13,6 @@ export interface InputProps
 
 const Input: React.FC<InputProps> = ({
   className = '',
-  onChange = () => {},
-  readOnly = false,
   fauxDisabled = false,
   forwardedRef: ref,
   ...passedProps
@@ -24,9 +22,7 @@ const Input: React.FC<InputProps> = ({
       className={classNames(styles.Input, className, {
         [styles.disabled]: fauxDisabled,
       })}
-      readOnly={readOnly}
       ref={ref || undefined}
-      onChange={onChange}
       {...passedProps}
     />
   );

--- a/src/components/Input/README.md
+++ b/src/components/Input/README.md
@@ -4,6 +4,10 @@
 
 The basic `<Input />` doesn't add any behavior to the HTML element, it just adds styles.
 
+The _onChange_ prop can be explictily transmitted to the component, otherwise all other props are transparently
+forwarded onto the
+underlying `<input />`.
+
 It also provides 1 custom prop
 
 - _fauxDisabled_: Applies the same style as disabled, but, unlike the real thing, doesn't stop click events. Useful for adding tooltips or other helpful behavior when a user tries to interact with a disabled field.

--- a/src/components/Input/story.tsx
+++ b/src/components/Input/story.tsx
@@ -32,17 +32,16 @@ storiesOf('Planets/Input', module)
     'Overview',
     () => (
       <Wrap>
-        <label className="text-xl inline-block mb-2">{`<Input />`}</label>
-        <Input
-          disabled={boolean('disabled (HTML)', false)}
-          fauxDisabled={boolean('fauxDisabled', false)}
-          onChange={action('onChange (HTML)')}
-          className={text('className (HTML)', 'w-full')}
-          placeholder={text('placeholder(HTML)', 'Placeholder')}
-          value={text('value (HTML)', '')}
-          pattern={text('pattern (HTML)', '.*')}
-          type={text('type (HTML)', '')}
-        />
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label className="text-xl inline-block mb-2">
+          {`<Input />`}
+          <Input
+            id="SampleInput"
+            className={text('className (HTML)', 'w-full')}
+            onChange={action('onChange (HTML)')}
+            fauxDisabled={boolean('fauxDisabled', false)}
+          />
+        </label>
       </Wrap>
     ),
     {
@@ -56,7 +55,7 @@ storiesOf('Planets/Input', module)
     'Examples',
     () => (
       <Wrap>
-        <h2 className="text-2xl leading-snug">Basic Input Examples</h2>
+        <h2 className="text-2xl leading-snug">Input Examples</h2>
         <div className="w-full md:w-1/3 mt-6">
           <InteractiveInput className="w-full" placeholder="Type here" />
         </div>
@@ -75,6 +74,36 @@ storiesOf('Planets/Input', module)
         </div>
         <div className="w-full md:w-1/3 mt-6">
           <Input className="w-full" fauxDisabled value="fauxDisabled" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="date" value="1967-03-01" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="month" value="1967-03" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="week" value="1967-W09" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="time" value="10:31" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="email" value="foo@bar.com" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="tel" value="512-867-5309" />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input
+            className="w-full"
+            type="range"
+            max="100"
+            value="70"
+            step="10"
+          />
+        </div>
+        <div className="w-full md:w-1/3 mt-6">
+          <Input className="w-full" type="color" value="#00CED1" />
         </div>
       </Wrap>
     ),


### PR DESCRIPTION
The component doesn't do anything special with `readOnly` ~~and `onChange`~~, so there's no reason to privilege these particular attributes in the component.

Also added some more `<input />` types because they're so cool.