### PR TITLE
feat: Button passes size prop to nested Addons via context

### DIFF
--- a/src/components/Button/Addon/Addon.tsx
+++ b/src/components/Button/Addon/Addon.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import PropTypes from 'prop-types';
+import React, { useContext } from 'react';
 import classNames from 'classnames';
 
+import ButtonContext from '../Button.context';
 import styles from './Addon.module.css';
 import { TButtonSize } from '../types';
 
@@ -12,23 +12,19 @@ export interface AddonProps {
 
 const Addon: React.FC<AddonProps> = ({
   className = '',
-  size = 'md',
+  size: customSize,
   ...passedProps
-}) => (
-  <div
-    {...passedProps}
-    className={classNames(className, styles.Addon, styles[size])}
-  />
-);
+}) => {
+  const buttonContext = useContext(ButtonContext);
 
-Addon.propTypes = {
-  className: PropTypes.string,
-  size: PropTypes.oneOf(['sm', 'md', 'lg']),
-};
+  const size = customSize || buttonContext.size || 'md';
 
-Addon.defaultProps = {
-  className: '',
-  size: 'md',
+  return (
+    <div
+      {...passedProps}
+      className={classNames(className, styles.Addon, styles[size])}
+    />
+  );
 };
 
 Addon.displayName = 'ButtonAddon';

--- a/src/components/Button/Button.context.ts
+++ b/src/components/Button/Button.context.ts
@@ -1,0 +1,7 @@
+import { createContext } from 'react';
+
+type ContextProps = {
+  size?: string;
+};
+
+export default createContext<ContextProps>({});

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,90 +1,115 @@
 import React from 'react';
-import { mount, shallow } from 'enzyme';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import Button from '.';
 
 describe('Button', () => {
   it('renders a `button` tag without error', () => {
-    const wrapper = mount(<Button />);
-    const inner = wrapper.childAt(0);
-    expect(inner.name()).toEqual('button');
+    render(<Button />);
+    expect(screen.getByRole('button')).toMatchSnapshot();
   });
 
   it('You can override default props', () => {
-    const wrapper = mount(<Button type="submit" />);
-    expect(wrapper.prop('type')).toEqual('submit');
+    render(<Button type="submit">Boom</Button>);
+    expect(screen.getByRole('button').getAttribute('type')).toEqual('submit');
   });
 
   describe('props.children', () => {
     it('renders strings', () => {
-      const wrapper = shallow(<Button>Boom</Button>);
-      expect(wrapper.text()).toEqual('Boom');
+      render(<Button className="foo">Boom</Button>);
+      expect(screen.getByRole('button').textContent).toEqual('Boom');
     });
 
     it('renders React nodes', () => {
-      const wrapper = shallow(
-        <Button>
-          <span>Boom</span>
+      render(
+        <Button className="foo">
+          <span data-testid="bar">Boom</span>
         </Button>
       );
 
-      expect(wrapper.text()).toEqual('Boom');
+      expect(screen.getByRole('button').textContent).toEqual('Boom');
+      expect(screen.getByTestId('bar')).toBeTruthy();
     });
   });
 
   describe('props.className', () => {
     it('adds custom className', () => {
-      const wrapper = shallow(<Button className="foo" />);
-      expect(wrapper.hasClass('foo')).toEqual(true);
+      render(<Button className="foo">Boom</Button>);
+      expect(screen.getByRole('button').classList).toContain('foo');
     });
   });
 
-  describe('props.hollow', () => {
-    // Our current test build doesn't do css modules, so this won't work
-    // it('adds hollow className', () => {
-    //   const wrapper = shallow(<Button hollow />);
-    //   expect(wrapper.hasClass(style.hollow)).toEqual(true);
-    // });
-  });
-
   describe('props.level', () => {
-    // Our current test build doesn't do css modules, so this won't work
-    // it.ignore('adds "primary" level className', () => {
-    //   const wrapper = shallow(<Button level="primary" />);
-    //   expect(wrapper.hasClass(style.primary)).toEqual(true);
-    // });
+    it('adds custom className', () => {
+      render(<Button level="primary">Boom</Button>);
+      expect(screen.getByRole('button').classList).toContain('primary');
+    });
   });
 
   describe('props.size', () => {
-    it('does not pass size prop to `Addon` children', () => {
-      const wrapper = mount(
-        <Button size="md">
-          <Button.Addon size="md" />
-        </Button>
-      );
-      let addon = wrapper.find(Button.Addon);
-      expect(addon.props().size).toEqual('md');
-      wrapper.setProps({ size: 'sm' });
-      addon = wrapper.find(Button.Addon);
-      expect(addon.props().size).toEqual('md');
-      wrapper.setProps({ size: 'lg' });
-      addon = wrapper.find(Button.Addon);
-      expect(addon.props().size).toEqual('md');
+    describe('is available to `Addon` children by default', () => {
+      it('sm', () => {
+        render(
+          <Button size="sm">
+            <Button.Addon>Addon</Button.Addon>
+          </Button>
+        );
+
+        expect(screen.getByText('Addon').classList).toContain('sm');
+      });
+
+      it('lg', () => {
+        render(
+          <Button size="lg">
+            <Button.Addon>Addon</Button.Addon>
+          </Button>
+        );
+
+        expect(screen.getByText('Addon').classList).toContain('lg');
+      });
+    });
+
+    describe('can be overridden by `Addon` children', () => {
+      it('sm', () => {
+        render(
+          <Button size="sm">
+            <Button.Addon size="md">Addon</Button.Addon>
+          </Button>
+        );
+
+        expect(screen.getByText('Addon').classList).toContain('md');
+      });
+
+      it('lg', () => {
+        render(
+          <Button size="lg">
+            <Button.Addon size="md">Addon</Button.Addon>
+          </Button>
+        );
+
+        expect(screen.getByText('Addon').classList).toContain('md');
+      });
     });
   });
 
   describe('props.href', () => {
     it('renders an anchor tag when there is an href', () => {
-      const wrapper = mount(<Button href="#example" />);
-      const inner = wrapper.childAt(0);
-      expect(inner.name()).toEqual('a');
+      render(<Button href="#example">Boom</Button>);
+      expect(screen.getByRole('link')).toBeTruthy();
     });
 
     it('renders a button tag when there is not href', () => {
       const callback = jest.fn();
-      const wrapper = mount(<Button onClick={callback} />);
-      const inner = wrapper.childAt(0);
-      expect(inner.name()).toEqual('button');
+
+      render(<Button onClick={callback}>Boom</Button>);
+
+      const button = screen.getByRole('button');
+      userEvent.click(button);
+
+      expect(button).toBeTruthy();
+      expect(callback).toBeCalledTimes(1);
     });
   });
 });

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button renders a \`button\` tag without error 1`] = `
+<button
+  class="Button secondary lg"
+  type="button"
+/>
+`;

--- a/src/components/Button/story.tsx
+++ b/src/components/Button/story.tsx
@@ -139,18 +139,55 @@ storiesOf('Planets/Button', module)
           <hr />
           <h2>Add-ons</h2>
           <div style={{ marginBottom: '20px' }}>
-            <Button>
-              <Button.Addon>
-                <Icon
-                  fill="currentColor"
-                  height="16"
-                  name="check"
-                  style={{ display: 'block' }}
-                  width="16"
-                />
-              </Button.Addon>
-              With left addon
-            </Button>
+            <span
+              style={{
+                display: 'inline-block',
+                marginRight: '20px',
+                marginBottom: '10px',
+              }}
+            >
+              <Button level="secondary" size="sm">
+                <Button.Addon>
+                  <Icon
+                    fill="currentColor"
+                    height="16"
+                    name="check"
+                    style={{ display: 'block' }}
+                    width="16"
+                  />
+                </Button.Addon>
+                Small, with left addon
+              </Button>
+            </span>
+            <span
+              style={{
+                display: 'inline-block',
+                marginRight: '20px',
+                marginBottom: '10px',
+              }}
+            >
+              <Button level="primary" size="lg">
+                Large, with 2 right addons
+                <Button.Addon>
+                  <Icon
+                    fill="currentColor"
+                    height="16"
+                    name="check"
+                    style={{ display: 'block' }}
+                    width="16"
+                  />
+                </Button.Addon>
+                <Button.Addon>
+                  <Icon
+                    fill="currentColor"
+                    height="16"
+                    name="check"
+                    style={{ display: 'block' }}
+                    width="16"
+                  />
+                </Button.Addon>
+              </Button>
+            </span>
           </div>
           <hr />
           <h2>Circle</h2>


### PR DESCRIPTION
This fixes 2 issues from _way_ back when we first converted to TS.

1. Wrap string-type top level children of the `Button` component in `span`s, which makes `Button.Addon` side spacing work correctly.
2. Pass down the `size` prop from the `Button` to any `Button.Addon` children. That removes the need for extra JSX attributes in most cases.

`Button`s used to do this stuff, but the code was a little janky, and it was removed as part of the TS mgration.

**Context**
Now that I'm working on a codemod to upgrade to RoverUI `Button`s on a different project, it would be really nice to _not_ have to add `<Button.Addon size="lg">` attributes everywhere they're used.