### PR TITLE
Chore: Deprecate Node 10.x support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -33,7 +33,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2
@@ -51,7 +51,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/_templates/component/new/Component.tsx.t
+++ b/_templates/component/new/Component.tsx.t
@@ -5,22 +5,19 @@ unless_exists: true
 <% PascalName = h.changeCase.pascal(name) %>
 import React from 'react';
 import classNames from 'classnames';
-import { ClassValue } from 'classnames/types';
 
 import styles from './<%= PascalName %>.module.css';
 
 interface <%= PascalName %>Props {
-  className?: ClassValue;
+  className?: string;
 }
 
 const <%= PascalName %>: React.FC<<%= PascalName %>Props> = ({
-  className: klassName = '',
+  className = '',
   ...props
 }) => {
-  const className = classNames(styles.<%= PascalName %>, klassName);
-
   return (
-    <div {...props} className={className}>
+    <div {...props} className={classNames(styles.<%= PascalName %>, className)}>
       Hello World, from <%= PascalName %>!
     </div>
   );

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "module": "dist/index.module.js",
   "jsnext:main": "dist/index.es.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "husky": {
     "hooks": {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import { CSSTransition } from 'react-transition-group';
 import classNames from 'classnames';
-import { ClassValue } from 'classnames/types';
 
 import ReactDOM from 'react-dom';
 import styles from './Modal.module.css';
@@ -17,7 +16,7 @@ type Level = 'primary' | 'warning' | 'info' | 'danger';
 
 interface ModalProps {
   children?: React.ReactNode;
-  className?: ClassValue;
+  className?: string;
   isOpen?: boolean;
   onClose?: () => void;
   size?: Size;

--- a/src/components/Pill/Pill.tsx
+++ b/src/components/Pill/Pill.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { ClassValue } from 'classnames/types';
 import Addon from './Addon';
 
 import styles from './Pill.module.css';
@@ -9,7 +8,7 @@ import styles from './Pill.module.css';
 export interface PillProps
   extends Omit<React.HTMLAttributes<HTMLDivElement>, 'className' | 'onClick'> {
   checked?: boolean;
-  className?: ClassValue;
+  className?: string;
   onClick?: (() => void) | null;
 }
 

--- a/src/stories/storybook-helpers.tsx
+++ b/src/stories/storybook-helpers.tsx
@@ -52,8 +52,11 @@ export const Wrap = BuildHelper('Wrap', 'm-5 rounded bg-white shadow-md p-4');
 export const Spacer = BuildHelper('Spacer', 'mb-5');
 export const Title = BuildHelper('Title', 'text-xl mb-5 border-b', 'h3');
 
+type InputValue = string | string[] | number | undefined;
+
 interface InteractiveInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
+  defaultValue?: InputValue;
   fauxDisabled?: boolean;
   InputRenderer: React.FC<React.InputHTMLAttributes<HTMLInputElement>>;
   onChange?: () => void;
@@ -66,9 +69,7 @@ export const InteractiveInput: React.FC<InteractiveInputProps> = ({
   defaultValue,
   ...passedProps
 }) => {
-  const [value, setValue] = useState<string | string[] | number | undefined>(
-    defaultValue
-  );
+  const [value, setValue] = useState<InputValue>(defaultValue);
   const [checked, setChecked] = useState<boolean | undefined>(defaultChecked);
 
   return (


### PR DESCRIPTION
This will semantically require a major version, since dropping support for Node 10.x is a breaking change.
However, an internal poll of known consumers indicates _no one_ is using Node 10, and it's no longer a long-term support (LTS) version; so the impact should be minimal to non-existent.