### PR TITLE
Add radio input

### DIFF
--- a/ORGANIZATION.md
+++ b/ORGANIZATION.md
@@ -56,6 +56,7 @@ Currently, there is no clear, definitive organization to our RoverUI component l
   - ListControlDefaultItem
   - MultiLineInput
   - PasswordInput
+  - Radio
   - Select
   - SmallCheckbox(?)
   - TextArea

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -40,6 +40,7 @@ const App = () => {
   const [tooltipOpen, setTooltipOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [inputCheckboxValue, setInputCheckboxValue] = useState(false);
+  const [inputRadioValue, setInputRadioValue] = useState(false);
   const [inputTimeValue, setInputTimeValue] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
 
@@ -408,6 +409,19 @@ const App = () => {
           type="checkbox"
         />{' '}
         {JSON.stringify(inputCheckboxValue)}
+      </Section>
+
+      <Section title="Input.Radio">
+        <h1>Input.Radio</h1>
+        <Input
+          onChange={(e) =>
+            console.log(e.target.checked) ||
+            setInputRadioValue(e.target.checked)
+          }
+          checked={inputRadioValue}
+          type="radio"
+        />{' '}
+        {JSON.stringify(inputRadioValue)}
       </Section>
 
       <Section title="InputTime">

--- a/src/components/Input/Radio/README.md
+++ b/src/components/Input/Radio/README.md
@@ -1,0 +1,9 @@
+# \<Radio\>
+
+### Radio component is a thin wrapper around an HTML input[type="radio"] element
+
+The basic `<Radio />` delegates all normal input behavior to the HTML element, and adds custom styles.
+
+It also provides 1 custom prop:
+
+- _fauxDisabled_: Applies the same style as disabled, but, unlike the real thing, doesn't stop propagation of events. Useful for adding tooltips or other helpful behavior when a user tries to interact with a disabled field. Because it doesn't stop click or change events, the consumer is responsible for making faux-disabled fields read-only.

--- a/src/components/Input/Radio/Radio.module.css
+++ b/src/components/Input/Radio/Radio.module.css
@@ -1,0 +1,59 @@
+.Radio {
+  position: relative;
+  display: inline-block;
+  /* height: var(--rvr-radio-size);
+  width: var(--rvr-radio-size); */
+  height: 24px;
+  width: 24px;
+}
+
+.svg {
+  transition: var(--rvr-transition-duration-fast) var(--rvr-linear) box-shadow;
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.input {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  opacity: 0;
+  z-index: 1;
+  display: block;
+}
+
+.outline {
+  fill: var(--rvr-color-font);
+  transition: var(--rvr-transition-duration-fast) var(--rvr-linear) fill;
+}
+
+.inner {
+  fill: var(--rvr-white);
+}
+
+input:checked + .svg .outline {
+  fill: var(--rvr-color-primary);
+}
+
+input:hover + .svg .outline {
+  fill: var(--rvr-color-primary-hover);
+}
+
+input:focus + .svg {
+  outline: 0 transparent none;
+  box-shadow:
+    0px 0px 0px 2px var(--rvr-white),
+    0px 0px 1px 3px var(--rvr-color-primary-hover),
+    0px 0px 8px 2px var(--rvr-color-primary-hover);
+}
+
+input:disabled + .svg .outline {
+  fill: var(--rvr-color-disabled);
+}
+
+input:checked + .svg .inner {
+  display: none;
+}

--- a/src/components/Input/Radio/Radio.module.css
+++ b/src/components/Input/Radio/Radio.module.css
@@ -1,10 +1,8 @@
 .Radio {
   position: relative;
   display: inline-block;
-  /* height: var(--rvr-radio-size);
-  width: var(--rvr-radio-size); */
-  height: 24px;
-  width: 24px;
+  height: var(--rvr-radio-size);
+  width: var(--rvr-radio-size);
 }
 
 .svg {
@@ -24,14 +22,17 @@
   z-index: 1;
   display: block;
 }
-
 .outline {
   fill: var(--rvr-color-font);
   transition: var(--rvr-transition-duration-fast) var(--rvr-linear) fill;
+  border-width: medium;
 }
 
 .inner {
-  fill: var(--rvr-white);
+  fill: none;
+}
+.Radio.checked .outline {
+  fill: var(--rvr-color-primary);
 }
 
 input:checked + .svg .outline {
@@ -55,5 +56,27 @@ input:disabled + .svg .outline {
 }
 
 input:checked + .svg .inner {
-  display: none;
+  fill: var(--rvr-color-primary);
+}
+
+.Radio.checked .check,
+.indeterminate + .svg .dash {
+  display: initial;
+  fill: var(--rvr-white);
+}
+
+.Radio.disabled .svg {
+  box-shadow: none;
+}
+
+input:disabled + .svg .outline,
+.Radio.disabled .svg .outline {
+  fill: var(--rvr-color-disabled);
+  box-shadow: none;
+}
+
+input:disabled + .svg .inner,
+.Radio.disabled .svg .inner {
+  fill: var(--rvr-color-disabled);
+  box-shadow: none;
 }

--- a/src/components/Input/Radio/Radio.tsx
+++ b/src/components/Input/Radio/Radio.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import classNames from 'classnames';
+
+import type { InputProps } from '../Input';
+
+import RadioSvg from './RadioSvg';
+import styles from './Radio.module.css';
+
+interface RadioWithRefProps extends InputProps {
+  forwardedRef?: React.Ref<HTMLInputElement>;
+}
+
+const RadioWithRef: React.FC<RadioWithRefProps> = ({
+  checked = false,
+  className = '',
+  forwardedRef: ref,
+  ...passedProps
+}) => {
+  return (
+    <div
+      className={classNames(styles.Radio, className, {
+        [styles.checked]: checked,
+      })}
+    >
+      <input
+        checked={checked}
+        className={styles.input}
+        ref={ref || undefined}
+        type="radio"
+        {...passedProps}
+      />
+      <RadioSvg aria-hidden className={styles.svg} />
+    </div>
+  );
+};
+
+const Radio = React.forwardRef<HTMLInputElement, InputProps>((props, ref) => (
+  <RadioWithRef {...props} forwardedRef={ref || undefined} />
+));
+
+export default Radio;

--- a/src/components/Input/Radio/Radio.tsx
+++ b/src/components/Input/Radio/Radio.tsx
@@ -8,12 +8,14 @@ import RadioSvg from './RadioSvg';
 import styles from './Radio.module.css';
 
 interface RadioWithRefProps extends InputProps {
+  fauxDisabled?: boolean;
   forwardedRef?: React.Ref<HTMLInputElement>;
 }
 
 const RadioWithRef: React.FC<RadioWithRefProps> = ({
   checked = false,
   className = '',
+  fauxDisabled = false,
   forwardedRef: ref,
   ...passedProps
 }) => {
@@ -21,12 +23,14 @@ const RadioWithRef: React.FC<RadioWithRefProps> = ({
     <div
       className={classNames(styles.Radio, className, {
         [styles.checked]: checked,
+        [styles.disabled]: fauxDisabled,
       })}
     >
       <input
         checked={checked}
         className={styles.input}
         ref={ref || undefined}
+        tabIndex={fauxDisabled ? -1 : undefined}
         type="radio"
         {...passedProps}
       />

--- a/src/components/Input/Radio/RadioSvg.tsx
+++ b/src/components/Input/Radio/RadioSvg.tsx
@@ -13,28 +13,13 @@ const Svg = ({ title = 'Radio', ...passedProps }) => (
   >
     <title>{title}</title>
     <g id="Radio" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-      <circle
-        className={styles.outer}
-        id="outer"
-        fill="#34404B"
-        cx="10"
-        cy="10"
-        r="10"
-      />
+      <circle className={styles.outer} id="outer" cx="10" cy="10" r="10" />
       <path
         className={styles.outline}
         d="M10,20 C4.4771525,20 0,15.5228475 0,10 C0,4.4771525 4.4771525,0 10,0 C15.5228475,0 20,4.4771525 20,10 C20,15.5228475 15.5228475,20 10,20 Z M10,18 C14.418278,18 18,14.418278 18,10 C18,5.581722 14.418278,2 10,2 C5.581722,2 2,5.581722 2,10 C2,14.418278 5.581722,18 10,18 Z"
         id="outline"
-        fill="#34404B"
       />
-      <circle
-        className={styles.inner}
-        id="inner"
-        fill="#DF7171"
-        cx="10"
-        cy="10"
-        r="5"
-      />
+      <circle className={styles.inner} id="inner" cx="10" cy="10" r="5" />
     </g>
   </svg>
 );

--- a/src/components/Input/Radio/RadioSvg.tsx
+++ b/src/components/Input/Radio/RadioSvg.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import styles from './Radio.module.css';
+
+const Svg = ({ title = 'Radio', ...passedProps }) => (
+  <svg
+    width="20px"
+    height="20px"
+    viewBox="0 0 20 20"
+    version="1.1"
+    xmlns="http://www.w3.org/2000/svg"
+    {...passedProps}
+  >
+    <title>{title}</title>
+    <g id="Radio" stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
+      <circle
+        className={styles.outer}
+        id="outer"
+        fill="#34404B"
+        cx="10"
+        cy="10"
+        r="10"
+      />
+      <path
+        className={styles.outline}
+        d="M10,20 C4.4771525,20 0,15.5228475 0,10 C0,4.4771525 4.4771525,0 10,0 C15.5228475,0 20,4.4771525 20,10 C20,15.5228475 15.5228475,20 10,20 Z M10,18 C14.418278,18 18,14.418278 18,10 C18,5.581722 14.418278,2 10,2 C5.581722,2 2,5.581722 2,10 C2,14.418278 5.581722,18 10,18 Z"
+        id="outline"
+        fill="#34404B"
+      />
+      <circle
+        className={styles.inner}
+        id="inner"
+        fill="#DF7171"
+        cx="10"
+        cy="10"
+        r="5"
+      />
+    </g>
+  </svg>
+);
+
+export default Svg;

--- a/src/components/Input/Radio/index.ts
+++ b/src/components/Input/Radio/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Radio';

--- a/src/components/Input/Radio/story.tsx
+++ b/src/components/Input/Radio/story.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { boolean, text } from '@storybook/addon-knobs';
@@ -38,6 +38,7 @@ storiesOf('Planets/Input/Radio', module)
             <Radio
               checked={boolean('checked', false)}
               className={text('className (HTML)', 'w-full')}
+              fauxDisabled={boolean('fauxDisabled', false)}
               id="SampleRadio"
               onChange={action('onChange (HTML)')}
             />
@@ -79,34 +80,104 @@ storiesOf('Planets/Input/Radio', module)
           </small>
         </p>
         <div>
-          {[[], ['checked'], ['disabled'], ['checked', 'disabled']].map(
-            (attributes) => {
-              const attributesId = ['atts', ...attributes].join('-');
-              const attributesLabel = attributes.join(' and ') || 'default';
+          {[
+            [],
+            ['checked'],
+            ['disabled'],
+            ['fauxDisabled'],
+            ['checked', 'disabled'],
+          ].map((attributes) => {
+            const attributesId = ['atts', ...attributes].join('-');
+            const attributesLabel = attributes.join(' and ') || 'default';
 
-              const attributesProps = attributes.reduce(
-                (acc, attr) => ({ ...acc, [attr]: true }),
-                {}
-              );
+            const attributesProps = attributes.reduce(
+              (acc, attr) => ({ ...acc, [attr]: true }),
+              {}
+            );
 
-              return (
-                <div className="my-6" key={attributesId}>
-                  <label htmlFor={attributesId}>
-                    {attributesLabel}{' '}
-                    <InteractiveInput
-                      InputRenderer={Radio}
-                      id={attributesId}
-                      onChange={action(`onChange ${attributesLabel}`)}
-                      {...attributesProps}
-                    />
-                  </label>
-                </div>
-              );
-            }
-          )}
+            return (
+              <div className="my-6" key={attributesId}>
+                <label htmlFor={attributesId}>
+                  {attributesLabel}{' '}
+                  <InteractiveInput
+                    InputRenderer={Radio}
+                    id={attributesId}
+                    onChange={action(`onChange ${attributesLabel}`)}
+                    {...attributesProps}
+                  />
+                </label>
+              </div>
+            );
+          })}
         </div>
       </Wrap>
     ),
+    {
+      info: {
+        inline: false,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Radio Group Example',
+    () => {
+      const [brother, setBrother] = useState('');
+      return (
+        <Wrap>
+          <form>
+            <h2>Example</h2>
+            <ul style={{ listStyleType: 'none' }}>
+              <li>
+                <label htmlFor="huey">
+                  <Radio
+                    checked={brother === 'huey'}
+                    name="brother"
+                    id="huey"
+                    value="huey"
+                    onChange={(e) => {
+                      action('onChange (HTML)')(e);
+                      setBrother('huey');
+                    }}
+                  />{' '}
+                  Huey
+                </label>
+              </li>
+              <li>
+                <label htmlFor="dewey">
+                  <Radio
+                    checked={brother === 'dewey'}
+                    name="brother"
+                    id="dewey"
+                    value="dewey"
+                    onChange={(e) => {
+                      action('onChange (HTML)')(e);
+                      setBrother('dewey');
+                    }}
+                  />{' '}
+                  Dewey
+                </label>
+              </li>
+              <li>
+                <label htmlFor="louie">
+                  <Radio
+                    checked={brother === 'louie'}
+                    name="brother"
+                    id="louie"
+                    value="louie"
+                    onChange={(e) => {
+                      action('onChange (HTML)')(e);
+                      setBrother('louie');
+                    }}
+                  />{' '}
+                  Louie
+                </label>
+              </li>
+            </ul>
+          </form>
+        </Wrap>
+      );
+    },
     {
       info: {
         inline: false,

--- a/src/components/Input/Radio/story.tsx
+++ b/src/components/Input/Radio/story.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { boolean, text } from '@storybook/addon-knobs';
+
+import Radio from '.';
+import Readme from './README.md';
+
+import { InteractiveInput, Wrap } from '../../../stories/storybook-helpers';
+
+storiesOf('Planets/Input/Radio', module)
+  .addParameters({
+    readme: {
+      sidebar: Readme,
+    },
+  })
+  .add(
+    'Overview',
+    () => (
+      <Wrap>
+        {/*
+          Eslint doesn't recognise that the `InteractiveInput` wrappers are
+          putting IDs on input elements, but they are.
+        */}
+        {/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
+        <label className="text-xl inline-block mb-2">
+          {`<Radio />`}
+          <p className="mt-6">
+            <small>
+              <em>
+                Radio is a bare input. You&apos;ll have to provide your own
+                label. &ldquo;Control&rdquo; components with integrated labels
+                and validation messages are on the roadmap.
+              </em>
+            </small>
+          </p>
+          <div>
+            <Radio
+              checked={boolean('checked', false)}
+              className={text('className (HTML)', 'w-full')}
+              id="SampleRadio"
+              onChange={action('onChange (HTML)')}
+            />
+          </div>
+        </label>
+      </Wrap>
+    ),
+    {
+      info: {
+        inline: true,
+        source: true,
+      },
+    }
+  )
+  .add(
+    'Examples',
+    () => (
+      <Wrap>
+        <h2>Radio</h2>
+        <p className="mt-6">
+          <small>
+            <em>
+              Radio is a bare input - the labels are provided for documentation
+              purposes only. &ldquo;Control&rdquo; components with integrated
+              labels and validation messages are on the roadmap.
+            </em>
+          </small>
+        </p>
+        <p className="mt-6">
+          <small>
+            This component is identical to {'`<Input type="radio" />`'}.
+          </small>
+        </p>
+        <p className="mt-6">
+          <small>
+            These examples use an `InteractiveInput` wrapper with an
+            `InputRenderer` prop. In actual implementations, just use a `Radio`
+            component, `onChange`, and `checked` props instead.
+          </small>
+        </p>
+        <div>
+          {[[], ['checked'], ['disabled'], ['checked', 'disabled']].map(
+            (attributes) => {
+              const attributesId = ['atts', ...attributes].join('-');
+              const attributesLabel = attributes.join(' and ') || 'default';
+
+              const attributesProps = attributes.reduce(
+                (acc, attr) => ({ ...acc, [attr]: true }),
+                {}
+              );
+
+              return (
+                <div className="my-6" key={attributesId}>
+                  <label htmlFor={attributesId}>
+                    {attributesLabel}{' '}
+                    <InteractiveInput
+                      InputRenderer={Radio}
+                      id={attributesId}
+                      onChange={action(`onChange ${attributesLabel}`)}
+                      {...attributesProps}
+                    />
+                  </label>
+                </div>
+              );
+            }
+          )}
+        </div>
+      </Wrap>
+    ),
+    {
+      info: {
+        inline: false,
+        source: true,
+      },
+    }
+  );

--- a/src/components/Input/index.ts
+++ b/src/components/Input/index.ts
@@ -1,3 +1,4 @@
 export { default } from './Input';
 export { default as Checkbox } from './Checkbox';
+export { default as Radio } from './Radio';
 export type { InputProps } from './Input';

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export {
 } from './components/TabMenu';
 
 export { default as Tooltip, EasyRichTooltip } from './components/Tooltip';
-export { default as Input, Checkbox } from './components/Input';
+export { default as Input, Checkbox, Radio } from './components/Input';
 export { default as InputTime } from './components/InputTime';
 export { default as Typography } from './components/Typography';
 export { default as Modal } from './components/Modal';

--- a/src/shared/sizing.css
+++ b/src/shared/sizing.css
@@ -66,6 +66,7 @@
 
   /* Form elements */
   --rvr-checkbox-size: calc(var(--rvr-baseSize) * 2.25); /* 18px */
+  --rvr-radio-size: calc(var(--rvr-baseSize) * 2); /* 16px */
 
   /* Dropdowns */
   /* Default EasyDropdown menu item with text label */

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -22,6 +22,7 @@ import '../components/Avatar/story';
 import '../components/Tooltip/story';
 import '../components/Input/story';
 import '../components/Input/Checkbox/story';
+import '../components/Input/Radio/story';
 import '../components/InputTime/story';
 import '../components/Typography/story';
 

--- a/src/stories/storybook-helpers.tsx
+++ b/src/stories/storybook-helpers.tsx
@@ -56,7 +56,6 @@ interface InteractiveInputProps
   extends React.InputHTMLAttributes<HTMLInputElement> {
   fauxDisabled?: boolean;
   InputRenderer: React.FC<React.InputHTMLAttributes<HTMLInputElement>>;
-  onChange?: () => void;
 }
 
 export const InteractiveInput: React.FC<InteractiveInputProps> = ({
@@ -78,7 +77,7 @@ export const InteractiveInput: React.FC<InteractiveInputProps> = ({
       onChange={(e) => {
         setValue(e.target.value);
         setChecked(e.target.checked);
-        onChange();
+        onChange(e);
       }}
       value={value !== undefined ? value : undefined}
     />


### PR DESCRIPTION
This PR adds radio to the list of Rover UI Inputs

I also removed the onChange prop in Interactive Input to make it more flexible and so it can properly report synthetic events in the Actions tab.
